### PR TITLE
Switch to proper x-k8s.io domain

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,6 +1,6 @@
-domain: cluster.x.k8s.io
-layout: go.kubebuilder.io/v2
-projectName: capn
+domain: cluster.x-k8s.io
+layout: go.kubebuilder.io/v3
+projectName: cluster-api-provider-nested
 repo: sigs.k8s.io/cluster-api-provider-nested
 resources:
 - group: controlplane

--- a/api/v1alpha4/groupversion_info.go
+++ b/api/v1alpha4/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha4 contains API Schema definitions for the controlplane v1alpha4 API group
 // +kubebuilder:object:generate=true
-// +groupName=controlplane.cluster.x.k8s.io
+// +groupName=controlplane.cluster.x-k8s.io
 package v1alpha4
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "controlplane.cluster.x.k8s.io", Version: "v1alpha4"}
+	GroupVersion = schema.GroupVersion{Group: "controlplane.cluster.x-k8s.io", Version: "v1alpha4"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/config/crd/bases/controlplane.cluster.x.k8s.io_nestedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x.k8s.io_nestedcontrolplanes.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
-  name: nestedcontrolplanes.controlplane.cluster.x.k8s.io
+  name: nestedcontrolplanes.controlplane.cluster.x-k8s.io
 spec:
-  group: controlplane.cluster.x.k8s.io
+  group: controlplane.cluster.x-k8s.io
   names:
     kind: NestedControlPlane
     listKind: NestedControlPlaneList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/controlplane.cluster.x.k8s.io_nestedcontrolplanes.yaml
+- bases/controlplane.cluster.x-k8s.io_nestedcontrolplanes.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/crd/patches/cainjection_in_nestedcontrolplanes.yaml
+++ b/config/crd/patches/cainjection_in_nestedcontrolplanes.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: nestedcontrolplanes.controlplane.cluster.x.k8s.io
+  name: nestedcontrolplanes.controlplane.cluster.x-k8s.io

--- a/config/crd/patches/webhook_in_nestedcontrolplanes.yaml
+++ b/config/crd/patches/webhook_in_nestedcontrolplanes.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: nestedcontrolplanes.controlplane.cluster.x.k8s.io
+  name: nestedcontrolplanes.controlplane.cluster.x-k8s.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/rbac/nestedcontrolplane_editor_role.yaml
+++ b/config/rbac/nestedcontrolplane_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nestedcontrolplane-editor-role
 rules:
 - apiGroups:
-  - controlplane.cluster.x.k8s.io
+  - controlplane.cluster.x-k8s.io
   resources:
   - nestedcontrolplanes
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - controlplane.cluster.x.k8s.io
+  - controlplane.cluster.x-k8s.io
   resources:
   - nestedcontrolplanes/status
   verbs:

--- a/config/rbac/nestedcontrolplane_viewer_role.yaml
+++ b/config/rbac/nestedcontrolplane_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nestedcontrolplane-viewer-role
 rules:
 - apiGroups:
-  - controlplane.cluster.x.k8s.io
+  - controlplane.cluster.x-k8s.io
   resources:
   - nestedcontrolplanes
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - controlplane.cluster.x.k8s.io
+  - controlplane.cluster.x-k8s.io
   resources:
   - nestedcontrolplanes/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,7 +7,7 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - controlplane.cluster.x.k8s.io
+  - controlplane.cluster.x-k8s.io
   resources:
   - nestedcontrolplanes
   verbs:
@@ -19,7 +19,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - controlplane.cluster.x.k8s.io
+  - controlplane.cluster.x-k8s.io
   resources:
   - nestedcontrolplanes/status
   verbs:

--- a/controllers/nestedcontrolplane_controller.go
+++ b/controllers/nestedcontrolplane_controller.go
@@ -34,8 +34,8 @@ type NestedControlPlaneReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=controlplane.cluster.x.k8s.io,resources=nestedcontrolplanes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=controlplane.cluster.x.k8s.io,resources=nestedcontrolplanes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=nestedcontrolplanes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=nestedcontrolplanes/status,verbs=get;update;patch
 
 func (r *NestedControlPlaneReconciler) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = r.Log.WithValues("nestedcontrolplane", req.NamespacedName)


### PR DESCRIPTION
Kubernetes won't allow any CRDs to be registered under the `k8s.io` domain, the original this was supposed to be `x-k8s.io` to match other k8s extensions.

Signed-off-by: Chris Hein <me@chrishein.com>