### PR TITLE
Updating controller-runtime to 0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	k8s.io/client-go v0.19.2
 	k8s.io/klog v1.0.0
 	sigs.k8s.io/cluster-api v0.3.11-0.20201112165251-91b70900dbaf
-	sigs.k8s.io/controller-runtime v0.7.0-alpha.5
+	sigs.k8s.io/controller-runtime v0.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,7 @@ github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.2.1 h1:fV3MLmabKIZ383XifUjFSwcoGee0v9qgPp8wy5svibE=
 github.com/go-logr/logr v0.2.1/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v0.3.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/zapr v0.2.0 h1:v6Ji8yBW77pva6NkJKQdHLAJKrIJKRHz0RXwPqCHSR4=
 github.com/go-logr/zapr v0.2.0/go.mod h1:qhKdvif7YF5GI9NWEpyxTSSBdGmzkNguibrdCNVPunU=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
@@ -721,6 +722,7 @@ sigs.k8s.io/cluster-api v0.3.11-0.20201112165251-91b70900dbaf h1:EPeZjqKnCYKOY6s
 sigs.k8s.io/cluster-api v0.3.11-0.20201112165251-91b70900dbaf/go.mod h1:siDh36v14xqSH6Z8Zkyiu0d7ead80C0RfkLgWtCeVCM=
 sigs.k8s.io/controller-runtime v0.7.0-alpha.5 h1:U0eZrtiuLMLE6RJTPCjr/CsrauJZc5gxqZxDE8HlBpg=
 sigs.k8s.io/controller-runtime v0.7.0-alpha.5/go.mod h1:03b1n6EtlDvuBPPEOHadJUusruwLWgoT4BDCybMibnA=
+sigs.k8s.io/controller-runtime v0.7.0/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98ZrroV1p+pIhoHsMm9wdU=
 sigs.k8s.io/kind v0.9.0/go.mod h1:cxKQWwmbtRDzQ+RNKnR6gZG6fjbeTtItp5cGf+ww+1Y=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=


### PR DESCRIPTION
Now that the official CR 0.7.0 release came out this moves away from the alpha dependency.

Signed-off-by: Chris Hein <me@chrishein.com>