### PR TITLE
✨ Adding virtualcluster to prow

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -23,3 +23,6 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${REPO_ROOT}/hack/ensure-go.sh"
 
 cd "${REPO_ROOT}" && make binaries
+
+cd "${REPO_ROOT}/virtualcluster/" && \
+  make build

--- a/scripts/ci-make.sh
+++ b/scripts/ci-make.sh
@@ -23,3 +23,6 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${REPO_ROOT}/hack/ensure-go.sh"
 
 cd "${REPO_ROOT}" && make docker-build
+
+cd "${REPO_ROOT}/virtualcluster/" && \
+	make build-images

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -27,3 +27,6 @@ cd "${REPO_ROOT}" && \
 	fetch_tools && \
 	setup_envs && \
 	make generate lint test
+
+cd "${REPO_ROOT}/virtualcluster/" && \
+	make test


### PR DESCRIPTION
This adds `virtualcluster/` subdirectory to the prow presubmit, this will allow us to validate if changes in PRs break VC or CAPN.

closes #64 

Signed-off-by: Chris Hein <me@chrishein.com>

/milestone v0.1.x
/kind cleanup