### PR TITLE
🌱 [VC] Adding go:1.16.2 docker image for VC

### DIFF
--- a/virtualcluster/Dockerfile
+++ b/virtualcluster/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.12 as builder
+FROM golang:1.16.2 as builder
 
 ENV GO111MODULE=on
 


### PR DESCRIPTION
When purely using the `virtualcluster/Dockerfile` and not using the `make build-images` target the older version of golang is incompatible with the latest `controller-runtime`. The original `make` target still works without this change which is why it wasn't caught.

Signed-off-by: Chris Hein <me@chrishein.com>