### PR TITLE
🐛 metadata.yaml clusterctl version to v1alpha3

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@
 # between patch versions.
 #
 # update this file only when a new major or minor version is released
-apiVersion: clusterctl.cluster.x-k8s.io/v1alpha4
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 releaseSeries:
 - major: 0
   minor: 1


### PR DESCRIPTION
to support #54 we need `clusterctl` to be able to marshal this file and even the `v0.4.0-beta.0` release doesn't have `v1alpha4` `clusterctl` support.

closes #119 

Signed-off-by: Chris Hein <me@chrishein.com>

/kind bug
/milestone v0.1.x