### PR TITLE
🐛Fix the issue of make release-notes in cluster-api-provider-nested

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ $(GOLANGCI_LINT): # Download golanci-lint using hack script into tools folder.
 		v1.40.1
 
 $(RELEASE_NOTES): $(TOOLS_DIR)/go.mod
-	cd $(TOOLS_DIR) && go build -tags=tools -o $(RELEASE_NOTES_BIN) sigs.k8s.io/cluster-api/hack/tools/release
+	cd $(TOOLS_DIR) && go build -tags=tools -o $(RELEASE_NOTES_BIN) ./release
 
 $(GO_APIDIFF): $(TOOLS_DIR)/go.mod
 	cd $(TOOLS_DIR) && go build -tags=tools -o $(GO_APIDIFF_BIN) github.com/joelanford/go-apidiff

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -1,0 +1,188 @@
+// +build tools
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+/*
+This tool prints all the titles of all PRs from previous release to HEAD.
+This needs to be run *before* a tag is created.
+
+Use these as the base of your release notes.
+*/
+
+const (
+	features      = ":sparkles: New Features"
+	bugs          = ":bug: Bug Fixes"
+	documentation = ":book: Documentation"
+	warning       = ":warning: Breaking Changes"
+	other         = ":seedling: Others"
+	unknown       = ":question: Sort these by hand"
+)
+
+var (
+	outputOrder = []string{
+		warning,
+		features,
+		bugs,
+		documentation,
+		other,
+		unknown,
+	}
+
+	fromTag = flag.String("from", "", "The tag or commit to start from.")
+)
+
+func main() {
+	flag.Parse()
+	os.Exit(run())
+}
+
+func lastTag() string {
+	if fromTag != nil && *fromTag != "" {
+		return *fromTag
+	}
+	cmd := exec.Command("git", "describe", "--tags", "--abbrev=0")
+	out, err := cmd.Output()
+	if err != nil {
+		return firstCommit()
+	}
+	return string(bytes.TrimSpace(out))
+}
+
+func firstCommit() string {
+	cmd := exec.Command("git", "rev-list", "--max-parents=0", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "UNKNOWN"
+	}
+	return string(bytes.TrimSpace(out))
+}
+
+func run() int {
+	lastTag := lastTag()
+	cmd := exec.Command("git", "rev-list", lastTag+"..HEAD", "--merges", "--pretty=format:%B")
+
+	merges := map[string][]string{
+		features:      {},
+		bugs:          {},
+		documentation: {},
+		warning:       {},
+		other:         {},
+		unknown:       {},
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("Error")
+		fmt.Println(string(out))
+		return 1
+	}
+
+	commits := []*commit{}
+	outLines := strings.Split(string(out), "\n")
+	for _, line := range outLines {
+		line = strings.TrimSpace(line)
+		last := len(commits) - 1
+		switch {
+		case strings.HasPrefix(line, "commit"):
+			commits = append(commits, &commit{})
+		case strings.HasPrefix(line, "Merge"):
+			commits[last].merge = line
+			continue
+		case line == "":
+		default:
+			commits[last].body = line
+		}
+	}
+
+	for _, c := range commits {
+		body := strings.TrimSpace(c.body)
+		var key, prNumber, fork string
+		switch {
+		case strings.HasPrefix(body, ":sparkles:"), strings.HasPrefix(body, "✨"):
+			key = features
+			body = strings.TrimPrefix(body, ":sparkles:")
+			body = strings.TrimPrefix(body, "✨")
+		case strings.HasPrefix(body, ":bug:"), strings.HasPrefix(body, "🐛"):
+			key = bugs
+			body = strings.TrimPrefix(body, ":bug:")
+			body = strings.TrimPrefix(body, "🐛")
+		case strings.HasPrefix(body, ":book:"), strings.HasPrefix(body, "📖"):
+			key = documentation
+			body = strings.TrimPrefix(body, ":book:")
+			body = strings.TrimPrefix(body, "📖")
+		case strings.HasPrefix(body, ":seedling:"), strings.HasPrefix(body, "🌱"):
+			key = other
+			body = strings.TrimPrefix(body, ":seedling:")
+			body = strings.TrimPrefix(body, "🌱")
+		case strings.HasPrefix(body, ":warning:"), strings.HasPrefix(body, "⚠️"):
+			key = warning
+			body = strings.TrimPrefix(body, ":warning:")
+			body = strings.TrimPrefix(body, "⚠️")
+		default:
+			key = unknown
+		}
+
+		body = strings.TrimSpace(body)
+		if body == "" {
+			continue
+		}
+		body = fmt.Sprintf("- %s", body)
+		fmt.Sscanf(c.merge, "Merge pull request %s from %s", &prNumber, &fork)
+		merges[key] = append(merges[key], formatMerge(body, prNumber))
+	}
+
+	// TODO Turn this into a link (requires knowing the project name + organization)
+	fmt.Printf("Changes since %v\n---\n", lastTag)
+
+	for _, key := range outputOrder {
+		mergeslice := merges[key]
+		if len(mergeslice) > 0 {
+			fmt.Println("## " + key)
+			for _, merge := range mergeslice {
+				fmt.Println(merge)
+			}
+			fmt.Println()
+		}
+	}
+
+	fmt.Println("")
+	fmt.Println("_Thanks to all our contributors!_ 😊")
+
+	return 0
+}
+
+type commit struct {
+	merge string
+	body  string
+}
+
+func formatMerge(line, prNumber string) string {
+	if prNumber == "" {
+		return line
+	}
+	return fmt.Sprintf("%s (%s)", line, prNumber)
+}


### PR DESCRIPTION
I fixed related issue in CAPI by PR https://github.com/kubernetes-sigs/cluster-api/pull/4796. And this PR is fixing for the issue https://github.com/kubernetes-sigs/cluster-api-provider-nested/issues/118.
After fixes, the cli `make release-notes` works well now:
```
 fenglixa@fenglixas-MacBook-Pro  ~/go/src/github.com/kubernetes-sigs/cluster-api-provider-nested   main ±  make release-notes
(unset)
cd hack/tools && go build -tags=tools -o bin/release-notes ./release
hack/tools/bin/release-notes
Changes since v0.1.0
---

_Thanks to all our contributors!_ 😊
 fenglixa@fenglixas-MacBook-Pro  ~/go/src/github.com/kubernetes-sigs/cluster-api-provider-nested   main ±  ll hack/tools/bin/release-notes
-rwxr-xr-x  1 fenglixa  staff  2484176 Jun 10 18:55 hack/tools/bin/release-notes
```
Fixes  #118 
