### PR TITLE
✨ Adding cluster-template.yaml for clusterctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,7 @@ release-manifests: $(RELEASE_DIR) $(KUSTOMIZE) ## Builds the manifests to publis
 	cat $(RELEASE_DIR)/control-plane-components.yaml >> $(RELEASE_DIR)/cluster-api-provider-nested-components.yaml
 	# Add metadata to the release artifacts
 	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
+	cp templates/cluster-template*.yaml $(RELEASE_DIR)/
 
 
 .PHONY: release-staging

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  controlPlaneEndpoint:
+    # currently this has to be the in-cluster endpoint, the in-cluster
+    # kubeconfig is used by controller-manager w/ ClusterIP services
+    # we can `port-forward` this service and be able to test
+    host: "${CLUSTER_NAME}-apiserver"
+    port: 6443
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    kind: NestedCluster
+    name: "${CLUSTER_NAME}"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    kind: NestedControlPlane
+    name: "${CLUSTER_NAME}-control-plane"
+  
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: NestedCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  controlPlaneEndpoint:
+    host: "localhost"
+    port: 6443
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+kind: NestedControlPlane
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  etcd:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    kind: NestedEtcd
+    name: "${CLUSTER_NAME}-nestedetcd"
+  apiserver:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    kind: NestedAPIServer
+    name: "${CLUSTER_NAME}-nestedapiserver"
+  controllerManager:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    kind: NestedControllerManager
+    name: "${CLUSTER_NAME}-nestedcontrollermanager"
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+kind: NestedEtcd
+metadata:
+  name: "${CLUSTER_NAME}-nestedetcd"
+spec:
+  replicas: 1
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+kind: NestedAPIServer
+metadata:
+  name: "${CLUSTER_NAME}-nestedapiserver"
+spec:
+  replicas: 1
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+kind: NestedControllerManager
+metadata:
+  name: "${CLUSTER_NAME}-nestedcontrollermanager"
+spec:
+  replicas: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
This will enable us to use `clusterctl generate config` to create the sample configs for deploying a cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #124

Signed-off-by: Chris Hein <me@chrishein.com>

/milestone v0.1.x
/kind feature