### PR TITLE
Remove ValidatingWebhookConfiguration when clearing all virtual cluster stuff

### DIFF
--- a/virtualcluster/doc/demo.md
+++ b/virtualcluster/doc/demo.md
@@ -341,6 +341,9 @@ kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-
 # The Virtual Cluster components
 kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-nested/master/virtualcluster/config/setup/all_in_one.yaml
 
+# The ValidatingWebhookConfiguration which generated runtime and is cluster-scoped resource
+kubectl delete ValidatingWebhookConfiguration virtualcluster-validating-webhook-configuration
+
 # The CRDs
 kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-nested/master/virtualcluster/config/crd/tenancy.x-k8s.io_virtualclusters.yaml
 kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-nested/master/virtualcluster/config/sampleswithspec/tenancy.x-k8s.io_clusterversions.yaml


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

The `ValidatingWebhookConfiguration` not clear when remove `virtual cluster` stuff, since it created by `vc-manager` and not belong to `namespace`