### PR TITLE
🐛 Adding back original all_in_one.yaml for VC

### DIFF
--- a/virtualcluster/config/setup/all_in_one.yaml
+++ b/virtualcluster/config/setup/all_in_one.yaml
@@ -1,0 +1,472 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vc-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: vc-manager-role
+rules:
+- apiGroups: 
+  - certificates.k8s.io
+  resources:
+  - signers
+  resourceNames:
+  # Support legacy versions, before signerName was added
+  - kubernetes.io/legacy-unknown
+  verbs: 
+  - approve
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - clusterversions/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - virtualclusters
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - virtualclusters/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - clusterversions/status
+  verbs:
+  - get
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vc-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vc-manager-role
+subjects:
+- kind: ServiceAccount
+  name: vc-manager
+  namespace: vc-manager
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vc-manager
+  namespace: vc-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vc-manager
+  namespace: vc-manager
+  labels:
+    app: vc-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vc-manager 
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: vc-manager
+        virtualcluster-webhook: "true"
+    spec:
+      serviceAccountName: vc-manager
+      containers:
+      - command:
+        - manager
+        args:
+        - --disable-stacktrace=true
+        - --enable-webhook=true
+        image: virtualcluster/manager-amd64
+        imagePullPolicy: Always
+        name: vc-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vc-syncer-role
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+    - endpoints
+    - namespaces
+    - pods
+    - secrets
+    - services
+    - serviceaccounts
+    - persistentvolumeclaims
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+- apiGroups:
+    - extensions
+  resources:
+    - ingresses
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+    - deletecollection
+- apiGroups:
+    - scheduling.k8s.io
+  resources:
+    - priorityclasses
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+- apiGroups:
+    - ""
+    - storage.k8s.io
+  resources:
+    - events
+    - nodes
+    - persistentvolumes
+    - storageclasses
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - ""
+    - storage.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+    - patch
+- apiGroups:
+    - ""
+  resources:
+    - namespaces/status
+    - pods/status
+    - services/status
+    - nodes/status
+    - persistentvolumes/status
+    - persistentvolumeclaims/status
+  verbs:
+    - get
+- apiGroups:
+    - tenancy.x-k8s.io
+  resources:
+    - virtualclusters
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - tenancy.x-k8s.io
+  resources:
+    - virtualclusters/status
+  verbs:
+    - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vc-syncer-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vc-syncer-role
+subjects:
+  - kind: ServiceAccount
+    name: vc-syncer
+    namespace: vc-manager
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vc-syncer
+  namespace: vc-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vc-syncer
+  namespace: vc-manager
+  labels:
+    app: vc-syncer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vc-syncer
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: vc-syncer
+    spec:
+      serviceAccountName: vc-syncer
+      containers:
+        - command:
+            - syncer
+          image: virtualcluster/syncer-amd64
+          imagePullPolicy: Always
+          name: vc-syncer
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            successThreshold: 1
+            tcpSocket:
+              port: 8080
+            timeoutSeconds: 1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: vn-agent-role
+rules:
+- apiGroups: 
+  - ""
+  resources: 
+  - pods
+  - pods/log
+  - pods/exec
+  - pods/portforward
+  - nodes/proxy
+  verbs:
+  - get
+  - list
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vn-agent-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vn-agent-role
+subjects:
+- kind: ServiceAccount
+  name: vn-agent
+  namespace: vc-manager
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vn-agent
+  namespace: vc-manager
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: empty-kubelet-client
+  namespace: vc-manager
+data:
+  client.crt: ""
+  client.key: ""
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vn-agent
+  namespace: vc-manager
+  labels:
+    app: vn-agent
+spec:
+  selector:
+    matchLabels:
+      app: vn-agent
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: vn-agent
+    spec:
+      serviceAccountName: vn-agent
+      hostNetwork: true
+      containers:
+        - command:
+          - vn-agent
+          - --cert-dir=/etc/vn-agent/
+          - --kubelet-client-certificate=/etc/vn-agent/pki/client.crt
+          - --kubelet-client-key=/etc/vn-agent/pki/client.key
+          image: virtualcluster/vn-agent-amd64
+          imagePullPolicy: Always
+          name: vn-agent
+          volumeMounts:
+          - name: kubelet-client-cert
+            mountPath: /etc/vn-agent/pki/
+      volumes:
+      - name: kubelet-client-cert
+        secret:
+          secretName: empty-kubelet-client

--- a/virtualcluster/doc/demo.md
+++ b/virtualcluster/doc/demo.md
@@ -59,7 +59,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-p
 To create all VirtualCluster components:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-nested/master/virtualcluster/config/setup/all_in_one_capi.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-nested/master/virtualcluster/config/setup/all_in_one.yaml
 ```
 
 Let's check out what we've installed:
@@ -339,7 +339,7 @@ Of course, you can delete all others VirtualCluster objects too to clean up ever
 kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-nested/master/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
 
 # The Virtual Cluster components
-kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-nested/master/virtualcluster/config/setup/all_in_one_capi.yaml
+kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-nested/master/virtualcluster/config/setup/all_in_one.yaml
 
 # The ValidatingWebhookConfiguration which generated runtime and is cluster-scoped resource
 kubectl delete ValidatingWebhookConfiguration virtualcluster-validating-webhook-configuration

--- a/virtualcluster/experiment/doc/demo.md
+++ b/virtualcluster/experiment/doc/demo.md
@@ -39,7 +39,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-p
 Install vc-manager and vc-scheduler in the vc-manager namespacing using the following command:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-nested/master/virtualcluster/experiment/config/setup/all_in_one_capi.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-nested/master/virtualcluster/experiment/config/setup/all_in_one.yaml
 ```
 
 Although the per super cluster syncer will be installed in the meta cluster, its configuration relies on the super cluster deployment. We will describe


### PR DESCRIPTION
**What this PR does / why we need it**:
I accidentally renamed instead of copying the manifest which broke the demo docs. This reverts those changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Reverts #142
Reverts #136 

Specifically that the all_in_one.yaml was just supposed to be copied while we transition from vc-manager provisioned to capi provisioned.

Signed-off-by: Chris Hein <me@chrishein.com>
