### PR TITLE
Correct the description for crd syncer

### DIFF
--- a/virtualcluster/doc/customresource-syncer.md
+++ b/virtualcluster/doc/customresource-syncer.md
@@ -11,7 +11,7 @@ CR Syncer relies on CR specific components, e.g., CR controller, CR Downward Syn
 
 In order for CR Syncer to work, custom defined resource type (CRD) must be deployed in both super cluster and tenant virtual cluster. CRD synchronization has been handled by: virtualcluster/pkg/syncer/resources/crd/
 
-CRDs with annotation: [tenancy.x-k8s.io/super.public](https://sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants/constants.go#L65-L66) will be synced up into tenant’s virtual cluster. The syncing happens when virtual cluster is created or once annotation is changed. 
+CRDs with label: [tenancy.x-k8s.io/super.public: "true"](https://sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants/constants.go#L67-L68) will be synced up into tenant’s virtual cluster. The syncing happens when virtual cluster is created or once annotation is changed. 
 
 CRD synchronization ensures all custom defined resource type is deployed in virtual cluster, and CRD cache is properly initialized.
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**
It's `labels` to enable the `CRD` syncer not `annotation`.

