### PR TITLE
make CRD from v1beta1 to v1

### DIFF
--- a/virtualcluster/config/crd/tenancy.x-k8s.io_clusterversions.yaml
+++ b/virtualcluster/config/crd/tenancy.x-k8s.io_clusterversions.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -11,49 +11,52 @@ spec:
     kind: ClusterVersion
     plural: clusterversions
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            apiServer:
-              properties:
-                metadata:
-                  type: object
-                service:
-                  type: object
-                statefulset:
-                  type: object
-              type: object
-            controllerManager:
-              properties:
-                metadata:
-                  type: object
-                service:
-                  type: object
-                statefulset:
-                  type: object
-              type: object
-            etcd:
-              properties:
-                metadata:
-                  type: object
-                service:
-                  type: object
-                statefulset:
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-      type: object
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              apiServer:
+                properties:
+                  metadata:
+                    type: object
+                  service:
+                    type: object
+                  statefulset:
+                    type: object
+                type: object
+              controllerManager:
+                properties:
+                  metadata:
+                    type: object
+                  service:
+                    type: object
+                  statefulset:
+                    type: object
+                type: object
+              etcd:
+                properties:
+                  metadata:
+                    type: object
+                  service:
+                    type: object
+                  statefulset:
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

make CRD become v1 of virtualcluster/config/crd/tenancy.x-k8s.io_clusterversions.yaml

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
