### PR TITLE
Add permission for secret deletecollect

### DIFF
--- a/virtualcluster/config/setup/all_in_one.yaml
+++ b/virtualcluster/config/setup/all_in_one.yaml
@@ -277,6 +277,7 @@ rules:
     - update
     - patch
     - delete
+    - deletecollection
 - apiGroups:
     - extensions
   resources:

--- a/virtualcluster/config/setup/all_in_one_aliyun.yaml
+++ b/virtualcluster/config/setup/all_in_one_aliyun.yaml
@@ -241,6 +241,7 @@ rules:
     - update
     - patch
     - delete
+    - deletecollection
 - apiGroups:
     - extensions
   resources:

--- a/virtualcluster/config/setup/all_in_one_capi.yaml
+++ b/virtualcluster/config/setup/all_in_one_capi.yaml
@@ -270,6 +270,7 @@ rules:
     - update
     - patch
     - delete
+    - deletecollection
 - apiGroups:
     - extensions
   resources:

--- a/virtualcluster/doc/customresource-syncer.md
+++ b/virtualcluster/doc/customresource-syncer.md
@@ -11,7 +11,7 @@ CR Syncer relies on CR specific components, e.g., CR controller, CR Downward Syn
 
 In order for CR Syncer to work, custom defined resource type (CRD) must be deployed in both super cluster and tenant virtual cluster. CRD synchronization has been handled by: virtualcluster/pkg/syncer/resources/crd/
 
-CRDs with label: [tenancy.x-k8s.io/super.public: "true"](https://sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants/constants.go#L67-L68) will be synced up into tenant’s virtual cluster. The syncing happens when virtual cluster is created or once annotation is changed. 
+CRDs with label: [tenancy.x-k8s.io/super.public: "true"](https://sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants/constants.go#L67-L68) will be synced up into tenant’s virtual cluster. The syncing happens when virtual cluster is created or once label is changed. 
 
 CRD synchronization ensures all custom defined resource type is deployed in virtual cluster, and CRD cache is properly initialized.
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
When I create a `ns` in tenant cluster then delete I found error raised in `syncer` 's  log, as this:
```
E0702 05:42:20.820948       1 dws.go:95] failed reconcile secret test/default-token-zp82r DELETE of cluster default-a32f71-vc-sample-1 secrets is forbidden: User "system:serviceaccount:vc-manager:vc-syncer" cannot deletecollection resource "secrets" in API group "" in the namespace "default-a32f71-vc-sample-1-test"
```

seems we do not assign enough permission to the `sa`, leak for `deletecollection`
