### PR TITLE
✨ Enabled Aggregate API for Virtual Cluster

### DIFF
--- a/virtualcluster/config/sampleswithspec/clusterversion_v1_loadbalancer.yaml
+++ b/virtualcluster/config/sampleswithspec/clusterversion_v1_loadbalancer.yaml
@@ -159,6 +159,14 @@ spec:
               - --enable-admission-plugins=NamespaceLifecycle,NodeRestriction,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
               - --apiserver-count=1
               - --endpoint-reconciler-type=master-count
+              - --enable-aggregator-routing=true
+              - --requestheader-client-ca-file=/etc/kubernetes/pki/root/tls.crt
+              - --requestheader-allowed-names=""
+              - --requestheader-username-headers=X-Remote-User
+              - --requestheader-group-headers=X-Remote-Group
+              - --requestheader-extra-headers-prefix=X-Remote-Extra-
+              - --proxy-client-key-file=/etc/kubernetes/pki/frontproxy/tls.key
+              - --proxy-client-cert-file=/etc/kubernetes/pki/frontproxy/tls.crt
               - --v=2
               ports:
               - containerPort: 6443
@@ -185,6 +193,9 @@ spec:
               - mountPath: /etc/kubernetes/pki/apiserver
                 name: apiserver-ca
                 readOnly: true
+              - mountPath: /etc/kubernetes/pki/frontproxy
+                name: front-proxy-ca
+                readOnly: true
               - mountPath: /etc/kubernetes/pki/root
                 name: root-ca
                 readOnly: true
@@ -205,6 +216,10 @@ spec:
               secret:
                 defaultMode: 420
                 secretName: root-ca
+            - name: front-proxy-ca
+              secret:
+                defaultMode: 420
+                secretName: front-proxy-ca
             - name: serviceaccount-rsa
               secret:
                 defaultMode: 420

--- a/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
+++ b/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
@@ -165,6 +165,14 @@ spec:
               - --enable-admission-plugins=NamespaceLifecycle,NodeRestriction,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
               - --apiserver-count=1
               - --endpoint-reconciler-type=master-count
+              - --enable-aggregator-routing=true
+              - --requestheader-client-ca-file=/etc/kubernetes/pki/root/tls.crt
+              - --requestheader-allowed-names=""
+              - --requestheader-username-headers=X-Remote-User
+              - --requestheader-group-headers=X-Remote-Group
+              - --requestheader-extra-headers-prefix=X-Remote-Extra-
+              - --proxy-client-key-file=/etc/kubernetes/pki/frontproxy/tls.key
+              - --proxy-client-cert-file=/etc/kubernetes/pki/frontproxy/tls.crt
               - --v=2
               ports:
               - containerPort: 6443
@@ -191,6 +199,9 @@ spec:
               - mountPath: /etc/kubernetes/pki/apiserver
                 name: apiserver-ca
                 readOnly: true
+              - mountPath: /etc/kubernetes/pki/frontproxy
+                name: front-proxy-ca
+                readOnly: true
               - mountPath: /etc/kubernetes/pki/root
                 name: root-ca
                 readOnly: true
@@ -211,6 +222,10 @@ spec:
               secret:
                 defaultMode: 420
                 secretName: root-ca
+            - name: front-proxy-ca
+              secret:
+                defaultMode: 420
+                secretName: front-proxy-ca
             - name: serviceaccount-rsa
               secret:
                 defaultMode: 420

--- a/virtualcluster/pkg/controller/pki/pki.go
+++ b/virtualcluster/pkg/controller/pki/pki.go
@@ -44,6 +44,7 @@ type ClusterCAGroup struct {
 	RootCA                   *CrtKeyPair
 	APIServer                *CrtKeyPair
 	ETCD                     *CrtKeyPair
+	FrontProxy               *CrtKeyPair
 	CtrlMgrKbCfg             string // the kubeconfig used by controller-manager
 	AdminKbCfg               string // the kubeconfig used by admin user
 	ServiceAccountPrivateKey *rsa.PrivateKey

--- a/virtualcluster/pkg/controller/secret/secret.go
+++ b/virtualcluster/pkg/controller/secret/secret.go
@@ -30,6 +30,7 @@ const (
 	RootCASecretName            = "root-ca"
 	APIServerCASecretName       = "apiserver-ca"
 	ETCDCASecretName            = "etcd-ca"
+	FrontProxyCASecretName      = "front-proxy-ca"
 	ControllerManagerSecretName = "controller-manager-kubeconfig"
 	AdminSecretName             = "admin-kubeconfig"
 	ServiceAccountSecretName    = "serviceaccount-rsa"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-nested/issues/166

@christopherhein @Fei-Guo 

This PR only covered VirtualCluster but does not cover nested control plane, will fix nested control plane in another PR.

@wangjsty ^^
