### PR TITLE
Use front-proxy-client CN for aggregate API

### DIFF
--- a/virtualcluster/config/sampleswithspec/clusterversion_v1_loadbalancer.yaml
+++ b/virtualcluster/config/sampleswithspec/clusterversion_v1_loadbalancer.yaml
@@ -161,7 +161,7 @@ spec:
               - --endpoint-reconciler-type=master-count
               - --enable-aggregator-routing=true
               - --requestheader-client-ca-file=/etc/kubernetes/pki/root/tls.crt
-              - --requestheader-allowed-names=""
+              - --requestheader-allowed-names=front-proxy-client
               - --requestheader-username-headers=X-Remote-User
               - --requestheader-group-headers=X-Remote-Group
               - --requestheader-extra-headers-prefix=X-Remote-Extra-

--- a/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
+++ b/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
@@ -167,7 +167,7 @@ spec:
               - --endpoint-reconciler-type=master-count
               - --enable-aggregator-routing=true
               - --requestheader-client-ca-file=/etc/kubernetes/pki/root/tls.crt
-              - --requestheader-allowed-names=""
+              - --requestheader-allowed-names=front-proxy-client
               - --requestheader-username-headers=X-Remote-User
               - --requestheader-group-headers=X-Remote-Group
               - --requestheader-extra-headers-prefix=X-Remote-Extra-


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

`--requestheader-allowed-names=""` indicates to an extension apiserver that any CN is acceptable.
Here we should use CN name `front-proxy-client ` which is more secure.

/cc @chrishenzie @Fei-Guo 