### PR TITLE
Remove restart.sh and start.sh in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,6 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY controlplane/ controlplane/
 
-RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
-  wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \
-  chmod +x /start.sh && chmod +x /restart.sh
-
 # Build
 ARG package=.
 ARG ARCH


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

time to time, my env stuck at download this restart.sh and start.sh those files are used for Tilt and not needed at capi 0.4.0 ,so remove them 

further info can refer https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/761

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
