### PR TITLE
Correct sample for crd syncer

### DIFF
--- a/virtualcluster/doc/customresource-syncer.md
+++ b/virtualcluster/doc/customresource-syncer.md
@@ -79,7 +79,7 @@ multiClusterFooController, err := mccontroller.NewMCController(&v1alpha1.Foo{}, 
 Foo Patroller can be constructed as:
 
 ```
-fooPatroller, err := patrol.NewPatroller(&alpha1.Project{}, c, pa.WithOptions(options.PatrolOptions))
+fooPatroller, err := patrol.NewPatroller(&v1alpha1.Foo{}, c, pa.WithOptions(options.PatrolOptions))
 ```
 
 Foo Listener is constructed as:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The sample CRD definition hould be `Foo`

