### PR TITLE
vc-syncer: remove invalid cluster name from knownClusterSet

### DIFF
--- a/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -160,7 +160,7 @@ func (c *controller) PatrollerDo() {
 		vList := &v1.PodList{}
 		if err := c.MultiClusterController.List(cluster, vList); err != nil {
 			klog.Errorf("error listing pod from cluster %s informer cache: %v", cluster, err)
-			knownClusterSet.Insert(cluster)
+			knownClusterSet.Delete(cluster)
 			continue
 		}
 

--- a/virtualcluster/pkg/syncer/resources/service/checker.go
+++ b/virtualcluster/pkg/syncer/resources/service/checker.go
@@ -77,7 +77,7 @@ func (c *controller) PatrollerDo() {
 		vList := &v1.ServiceList{}
 		if err := c.MultiClusterController.List(cluster, vList); err != nil {
 			klog.Errorf("error listing service from cluster %s informer cache: %v", cluster, err)
-			knownClusterSet.Insert(cluster)
+			knownClusterSet.Delete(cluster)
 			continue
 		}
 

--- a/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
+++ b/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
@@ -67,7 +67,7 @@ func (c *controller) PatrollerDo() {
 		vList := &v1.ServiceAccountList{}
 		if err := c.MultiClusterController.List(cluster, vList); err != nil {
 			klog.Errorf("error listing serviceaccount from cluster %s informer cache: %v", cluster, err)
-			knownClusterSet.Insert(cluster)
+			knownClusterSet.Delete(cluster)
 			continue
 		}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
bugfix: remove invalid cluster name from knownClusterSet 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
