### PR TITLE
Remove related kubeconfig file when exit

### DIFF
--- a/virtualcluster/cmd/kubectl-vc/exec.go
+++ b/virtualcluster/cmd/kubectl-vc/exec.go
@@ -154,6 +154,7 @@ func enterVCShell(kbFilePath, ns, name string) error {
 	c.Stderr = os.Stderr
 
 	defer func() {
+		_ = os.Remove(kbFilePath)
 		fmt.Printf("%s exit VirtualCluster %s/%s\n", warningPrompt, ns, name)
 	}()
 	return c.Run()


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Run `kubectl-vc exec` to move to tenant's workspace then run `exit` to exit.
should remove `kubeconfig` file for the tenant which generated by `kubectl-vc exec`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
