### PR TITLE
⚠️ syncer: clean opaqued keys before construct super cluster object

### DIFF
--- a/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/virtualcluster/pkg/syncer/conversion/equality.go
@@ -249,7 +249,7 @@ func (e vcEquality) checkDWKVEquality(pKV, vKV map[string]string) (map[string]st
 			// tenant pod should not use exceptional keys. it may conflicts with syncer.
 			continue
 		}
-		if e.isOpaquedKey(vk) {
+		if isOpaquedKey(e.config, vk) {
 			continue
 		}
 		pv, ok := pKV[vk]
@@ -264,7 +264,7 @@ func (e vcEquality) checkDWKVEquality(pKV, vKV map[string]string) (map[string]st
 		if hasPrefixInArray(pk, exceptionsList) {
 			continue
 		}
-		if e.isOpaquedKey(pk) {
+		if isOpaquedKey(e.config, pk) {
 			continue
 		}
 
@@ -292,15 +292,15 @@ func (e vcEquality) checkDWKVEquality(pKV, vKV map[string]string) (map[string]st
 	return updated, false
 }
 
-func (e vcEquality) isOpaquedKey(key string) bool {
-	if e.config == nil {
+func isOpaquedKey(config *config.SyncerConfiguration, key string) bool {
+	if config == nil {
 		return false
 	}
 	tokens := strings.SplitN(key, "/", 2)
 	if len(tokens) < 1 {
 		return false
 	}
-	for _, domain := range e.config.DefaultOpaqueMetaDomains {
+	for _, domain := range config.DefaultOpaqueMetaDomains {
 		if strings.HasSuffix(tokens[0], domain) {
 			return true
 		}
@@ -445,7 +445,7 @@ func (e vcEquality) checkInt64Equality(pObj, vObj *int64) (*int64, bool) {
 	return updated, false
 }
 
-// CheckConfigMapEqualit checks whether super master ConfigMap and virtual ConfigMap
+// CheckConfigMapEquality checks whether super master ConfigMap and virtual ConfigMap
 // are logically equal. The source of truth is virtual object.
 func (e vcEquality) CheckConfigMapEquality(pObj, vObj *v1.ConfigMap) *v1.ConfigMap {
 	var updated *v1.ConfigMap

--- a/virtualcluster/pkg/syncer/manager/manager_test.go
+++ b/virtualcluster/pkg/syncer/manager/manager_test.go
@@ -1,0 +1,473 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/apis/config"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/conversion"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/cluster"
+	mc "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/mccontroller"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/reconciler"
+)
+
+type fakeReconciler struct{}
+
+func (f fakeReconciler) Reconcile(reconciler.Request) (reconciler.Result, error) {
+	return reconciler.Result{}, nil
+}
+
+func MakeMultiClusterControllerWithFakeCluster(tb testing.TB, obj client.Object, objList client.ObjectList, vcList ...*v1alpha1.VirtualCluster) mc.MultiClusterInterface {
+	mcc, err := mc.NewMCController(obj, objList, &fakeReconciler{})
+	if err != nil {
+		tb.Errorf("create mc controller: %v", err)
+		return nil
+	}
+
+	for _, vc := range vcList {
+		fc := cluster.NewFakeTenantCluster(vc, nil, nil)
+		err = mcc.RegisterClusterResource(fc, mc.WatchOptions{})
+		if err != nil {
+			tb.Errorf("register cluster %v", err)
+			return nil
+		}
+		err = mcc.WatchClusterResource(fc, mc.WatchOptions{})
+		if err != nil {
+			tb.Errorf("add cluster %v", err)
+			return nil
+		}
+	}
+	return mcc
+}
+
+func TestBuildSuperClusterObject(t *testing.T) {
+	syncerConfig := &config.SyncerConfiguration{
+		DefaultOpaqueMetaDomains: []string{"kubernetes.io"},
+	}
+
+	vc := &v1alpha1.VirtualCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "v1",
+			Namespace: "t1",
+			UID:       "d64ea0c0-91f8-46f5-8643-c0cab32ab0cd",
+		},
+		Spec: v1alpha1.VirtualClusterSpec{
+			OpaqueMetaPrefixes: []string{"opaque.io"},
+		},
+	}
+	mcc := MakeMultiClusterControllerWithFakeCluster(t, &v1.Pod{}, &v1.PodList{}, vc)
+	ct := conversion.Convertor(syncerConfig, mcc)
+	time := metav1.Now()
+
+	clusterKey := conversion.ToClusterKey(vc)
+
+	attachVCMeta := func(obj client.Object) error {
+		var tenantScopeMetaInAnnotation = map[string]string{
+			constants.LabelCluster:     clusterKey,
+			constants.LabelNamespace:   "n1",
+			constants.LabelVCName:      "v1",
+			constants.LabelVCNamespace: "t1",
+		}
+		anno := obj.GetAnnotations()
+		if anno == nil {
+			anno = make(map[string]string)
+		}
+		for k, v := range tenantScopeMetaInAnnotation {
+			anno[k] = v
+		}
+		obj.SetAnnotations(anno)
+		labels := obj.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		var tenantScopeMetaInLabel = map[string]string{
+			constants.LabelVCName:      "v1",
+			constants.LabelVCNamespace: "t1",
+		}
+		for k, v := range tenantScopeMetaInLabel {
+			labels[k] = v
+		}
+		obj.SetLabels(labels)
+		return nil
+	}
+
+	tests := []struct {
+		name        string
+		cluster     string
+		obj         client.Object
+		expectedObj client.Object
+		errMsg      string
+	}{
+		{
+			name:    "cluster not found",
+			cluster: "not_found",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "n1",
+					Name:      "v1",
+				},
+			},
+			errMsg: "get virtualcluster",
+		},
+		{
+			name:    "normal case",
+			cluster: clusterKey,
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "n1",
+					Name:      "v1",
+					Labels: map[string]string{
+						"k": "v",
+					},
+					Annotations: map[string]string{
+						"k": "v",
+					},
+				},
+			},
+			expectedObj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: conversion.ToSuperClusterNamespace(clusterKey, "n1"),
+					Name:      "v1",
+					Labels: map[string]string{
+						"k": "v",
+					},
+					Annotations: map[string]string{
+						"k":                            "v",
+						constants.LabelUID:             "",
+						constants.LabelOwnerReferences: "null",
+					},
+				},
+			},
+		},
+		{
+			name:    "non empty meta",
+			cluster: clusterKey,
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "n1",
+					Name:      "v1",
+					UID:       "d64ea111-91f8-46f5-8643-c0cab32ab0cd",
+					Labels: map[string]string{
+						constants.LabelVCName:      "i want to overwrite",
+						constants.LabelVCNamespace: "i want to overwrite",
+					},
+					Annotations: map[string]string{
+						constants.LabelUID:             "i want to overwrite",
+						constants.LabelOwnerReferences: "i want to overwrite",
+						constants.LabelCluster:         "i want to overwrite",
+					},
+					ResourceVersion:            "1",
+					Generation:                 10001,
+					DeletionTimestamp:          &time,
+					DeletionGracePeriodSeconds: pointer.Int64(1),
+					OwnerReferences: []metav1.OwnerReference{
+						{Name: "1"},
+					},
+					Finalizers: []string{"f"},
+				},
+			},
+			expectedObj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: conversion.ToSuperClusterNamespace(clusterKey, "n1"),
+					Name:      "v1",
+					Annotations: map[string]string{
+						constants.LabelUID:             "d64ea111-91f8-46f5-8643-c0cab32ab0cd",
+						constants.LabelOwnerReferences: `[{"apiVersion":"","kind":"","name":"1","uid":""}]`,
+					},
+				},
+			},
+		},
+		{
+			name:    "have opaqued keys",
+			cluster: clusterKey,
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "n1",
+					Name:      "v1",
+					Labels: map[string]string{
+						"k":                 "v",
+						"m.kubernetes.io":   "v",
+						"m.kubernetes.io/a": "v",
+						"kubernetes.io/b":   "v",
+						"kubernetes.io":     "v",
+						"opaque.io/kk":      "v",
+						"m.opaque.io":       "v",
+					},
+					Annotations: map[string]string{
+						"k":               "v",
+						"m.kubernetes.io": "v",
+						"opaque.io/kk":    "v",
+						"m.opaque.io":     "v",
+					},
+				},
+			},
+			expectedObj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: conversion.ToSuperClusterNamespace(clusterKey, "n1"),
+					Name:      "v1",
+					Labels: map[string]string{
+						"k":           "v",
+						"m.opaque.io": "v",
+					},
+					Annotations: map[string]string{
+						"k":                            "v",
+						"m.opaque.io":                  "v",
+						constants.LabelUID:             "",
+						constants.LabelOwnerReferences: "null",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ct.BuildSuperClusterObject(tt.cluster, tt.obj)
+			if tt.errMsg != "" {
+				if err == nil {
+					t.Errorf("expected error %v, got empty", tt.errMsg)
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error %v, got %v", tt.errMsg, err.Error())
+					return
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+				return
+			}
+
+			err = attachVCMeta(tt.expectedObj)
+			if err != nil {
+				t.Errorf("unexpected error when attach vc meta: %v", err)
+				return
+			}
+			if !equality.Semantic.DeepEqual(got, tt.expectedObj) {
+				g, _ := json.MarshalIndent(got, "", "\t")
+				e, _ := json.MarshalIndent(tt.expectedObj, "", "\t")
+				t.Errorf("expected %v, got %v", string(e), string(g))
+			}
+		})
+	}
+}
+
+func TestBuildSuperClusterNamespace(t *testing.T) {
+	syncerConfig := &config.SyncerConfiguration{
+		DefaultOpaqueMetaDomains: []string{"kubernetes.io"},
+	}
+
+	vc := &v1alpha1.VirtualCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "v1",
+			Namespace: "t1",
+			UID:       "d64ea0c0-91f8-46f5-8643-c0cab32ab0cd",
+		},
+		Spec: v1alpha1.VirtualClusterSpec{
+			OpaqueMetaPrefixes: []string{"opaque.io"},
+		},
+	}
+	mcc := MakeMultiClusterControllerWithFakeCluster(t, &v1.Namespace{}, &v1.NamespaceList{}, vc)
+	ct := conversion.Convertor(syncerConfig, mcc)
+	time := metav1.Now()
+
+	clusterKey := conversion.ToClusterKey(vc)
+
+	attachVCMeta := func(obj client.Object) error {
+		var tenantScopeMetaInAnnotation = map[string]string{
+			constants.LabelCluster:     clusterKey,
+			constants.LabelNamespace:   "n1",
+			constants.LabelVCName:      "v1",
+			constants.LabelVCNamespace: "t1",
+			constants.LabelVCUID:       "d64ea0c0-91f8-46f5-8643-c0cab32ab0cd",
+		}
+		anno := obj.GetAnnotations()
+		if anno == nil {
+			anno = make(map[string]string)
+		}
+		for k, v := range tenantScopeMetaInAnnotation {
+			anno[k] = v
+		}
+		obj.SetAnnotations(anno)
+		return nil
+	}
+
+	tests := []struct {
+		name        string
+		cluster     string
+		obj         client.Object
+		expectedObj client.Object
+		errMsg      string
+	}{
+		{
+			name:    "cluster not found",
+			cluster: "not_found",
+			obj: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "n1",
+				},
+			},
+			errMsg: "get virtualcluster",
+		},
+		{
+			name:    "normal case",
+			cluster: clusterKey,
+			obj: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "n1",
+					Labels: map[string]string{
+						"k": "v",
+					},
+					Annotations: map[string]string{
+						"k": "v",
+					},
+				},
+			},
+			expectedObj: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: conversion.ToSuperClusterNamespace(clusterKey, "n1"),
+					Labels: map[string]string{
+						"k": "v",
+					},
+					Annotations: map[string]string{
+						"k":                "v",
+						constants.LabelUID: "",
+					},
+				},
+			},
+		},
+		{
+			name:    "non empty meta",
+			cluster: clusterKey,
+			obj: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "n1",
+					UID:  "d64ea111-91f8-46f5-8643-c0cab32ab0cd",
+					Labels: map[string]string{
+						constants.LabelVCName:      "i want to overwrite",
+						constants.LabelVCNamespace: "i want to overwrite",
+					},
+					Annotations: map[string]string{
+						constants.LabelUID:             "i want to overwrite",
+						constants.LabelOwnerReferences: "i want to overwrite",
+						constants.LabelCluster:         "i want to overwrite",
+					},
+					ResourceVersion:            "1",
+					Generation:                 10001,
+					DeletionTimestamp:          &time,
+					DeletionGracePeriodSeconds: pointer.Int64(1),
+					OwnerReferences: []metav1.OwnerReference{
+						{Name: "1"},
+					},
+					Finalizers: []string{"f"},
+				},
+			},
+			expectedObj: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: conversion.ToSuperClusterNamespace(clusterKey, "n1"),
+					Annotations: map[string]string{
+						constants.LabelUID: "d64ea111-91f8-46f5-8643-c0cab32ab0cd",
+					},
+				},
+			},
+		},
+		{
+			name:    "have opaqued keys",
+			cluster: clusterKey,
+			obj: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "n1",
+					Labels: map[string]string{
+						"k":                 "v",
+						"m.kubernetes.io":   "v",
+						"m.kubernetes.io/a": "v",
+						"kubernetes.io/b":   "v",
+						"kubernetes.io":     "v",
+						"opaque.io/kk":      "v",
+						"m.opaque.io":       "v",
+					},
+					Annotations: map[string]string{
+						"k":               "v",
+						"m.kubernetes.io": "v",
+						"opaque.io/kk":    "v",
+						"m.opaque.io":     "v",
+					},
+				},
+			},
+			expectedObj: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: conversion.ToSuperClusterNamespace(clusterKey, "n1"),
+					Labels: map[string]string{
+						"k":           "v",
+						"m.opaque.io": "v",
+					},
+					Annotations: map[string]string{
+						"k":                "v",
+						"m.opaque.io":      "v",
+						constants.LabelUID: "",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ct.BuildSuperClusterNamespace(tt.cluster, tt.obj)
+			if tt.errMsg != "" {
+				if err == nil {
+					t.Errorf("expected error %v, got empty", tt.errMsg)
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error %v, got %v", tt.errMsg, err.Error())
+					return
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+				return
+			}
+
+			err = attachVCMeta(tt.expectedObj)
+			if err != nil {
+				t.Errorf("unexpected error when attach vc meta: %v", err)
+				return
+			}
+			if !equality.Semantic.DeepEqual(got, tt.expectedObj) {
+				g, _ := json.MarshalIndent(got, "", "\t")
+				e, _ := json.MarshalIndent(tt.expectedObj, "", "\t")
+				t.Errorf("expected %v, got %v", string(e), string(g))
+			}
+		})
+	}
+}

--- a/virtualcluster/pkg/syncer/patrol/differ/differ_test.go
+++ b/virtualcluster/pkg/syncer/patrol/differ/differ_test.go
@@ -79,9 +79,9 @@ func TestDifferSet(t *testing.T) {
 
 func TestDifferSetDifference(t *testing.T) {
 	ta := ClusterObject{Key: "t1-n1/a", OwnerCluster: "t1", Object: makeObject("n1", "a")}
-	a := ClusterObject{Key: "t1-n1/a", Object: makeObject(conversion.ToSuperMasterNamespace("t1", "n1"), "a")}
+	a := ClusterObject{Key: "t1-n1/a", Object: makeObject(conversion.ToSuperClusterNamespace("t1", "n1"), "a")}
 	tb := ClusterObject{Key: "t1-n1/b", OwnerCluster: "t1", Object: makeObject("n1", "b")}
-	c := ClusterObject{Key: "t1-n1/c", Object: makeObject(conversion.ToSuperMasterNamespace("t1", "n1"), "c")}
+	c := ClusterObject{Key: "t1-n1/c", Object: makeObject(conversion.ToSuperClusterNamespace("t1", "n1"), "c")}
 
 	vSet := NewDiffSet(ta, tb)
 	pSet := NewDiffSet(a, c)
@@ -131,7 +131,7 @@ func Benchmark_Difference_1000(b *testing.B) {
 	for i := 0; i < groupNum; i++ {
 		for j := 0; j < totalNum/groupNum; j++ {
 			cluster := strconv.Itoa(i)
-			obj := makeObject(conversion.ToSuperMasterNamespace(cluster, "n"), strconv.Itoa(j))
+			obj := makeObject(conversion.ToSuperClusterNamespace(cluster, "n"), strconv.Itoa(j))
 			pSet.Insert(ClusterObject{
 				Object: obj,
 				Key:    DefaultClusterObjectKey(obj, ""),

--- a/virtualcluster/pkg/syncer/patrol/differ/handler.go
+++ b/virtualcluster/pkg/syncer/patrol/differ/handler.go
@@ -108,7 +108,7 @@ func DefaultDifferFilter(knownClusterSet sets.String) func(obj ClusterObject) bo
 func DefaultClusterObjectKey(obj metav1.Object, ownerCluster string) string {
 	var ns = obj.GetNamespace()
 	if ownerCluster != "" {
-		ns = conversion.ToSuperMasterNamespace(ownerCluster, ns)
+		ns = conversion.ToSuperClusterNamespace(ownerCluster, ns)
 	}
 	return fmt.Sprintf("%s%c%s", ns, '/', obj.GetName())
 }

--- a/virtualcluster/pkg/syncer/resources/configmap/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/configmap/checker_test.go
@@ -45,7 +45,7 @@ func TestConfigMapPatrol(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/configmap/dws_test.go
+++ b/virtualcluster/pkg/syncer/resources/configmap/dws_test.go
@@ -79,7 +79,7 @@ func TestDWConfigMapCreation(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -176,7 +176,7 @@ func TestDWConfigMapDeletion(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -274,7 +274,7 @@ func TestDWConfigMapUpdate(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	data1 := "data1"
 	data2 := "data2"

--- a/virtualcluster/pkg/syncer/resources/endpoints/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/endpoints/checker_test.go
@@ -41,7 +41,7 @@ func TestEndpointsPatrol(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/endpoints/dws.go
+++ b/virtualcluster/pkg/syncer/resources/endpoints/dws.go
@@ -53,7 +53,7 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 		}
 	}
 	klog.V(4).Infof("reconcile endpoints %s/%s for cluster %s", request.Namespace, request.Name, request.ClusterName)
-	targetNamespace := conversion.ToSuperMasterNamespace(request.ClusterName, request.Namespace)
+	targetNamespace := conversion.ToSuperClusterNamespace(request.ClusterName, request.Namespace)
 	pEndpoints, err := c.endpointsLister.Endpoints(targetNamespace).Get(request.Name)
 	pExists := true
 	if err != nil {
@@ -96,11 +96,7 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 }
 
 func (c *controller) reconcileEndpointsCreate(clusterName, targetNamespace, requestUID string, ep *v1.Endpoints) error {
-	vcName, vcNS, _, err := c.MultiClusterController.GetOwnerInfo(clusterName)
-	if err != nil {
-		return err
-	}
-	newObj, err := conversion.BuildMetadata(clusterName, vcNS, vcName, targetNamespace, ep)
+	newObj, err := c.Conversion().BuildSuperClusterObject(clusterName, ep)
 	if err != nil {
 		return err
 	}

--- a/virtualcluster/pkg/syncer/resources/endpoints/dws_test.go
+++ b/virtualcluster/pkg/syncer/resources/endpoints/dws_test.go
@@ -107,7 +107,7 @@ func TestDWEndpointsCreation(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -218,7 +218,7 @@ func TestDWEndpointsDeletion(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -314,7 +314,7 @@ func TestDWEndpointsUpdate(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	subset1 := []v1.EndpointSubset{
 		{

--- a/virtualcluster/pkg/syncer/resources/event/uws_test.go
+++ b/virtualcluster/pkg/syncer/resources/event/uws_test.go
@@ -112,7 +112,7 @@ func TestUWEvent(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/ingress/checker.go
+++ b/virtualcluster/pkg/syncer/resources/ingress/checker.go
@@ -118,7 +118,7 @@ func (c *controller) checkIngressesOfTenantCluster(clusterName string) {
 	klog.V(4).Infof("check ingresss consistency in cluster %s", clusterName)
 
 	for i, vIngress := range ingList.Items {
-		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vIngress.Namespace)
+		targetNamespace := conversion.ToSuperClusterNamespace(clusterName, vIngress.Namespace)
 		pIngress, err := c.ingressLister.Ingresses(targetNamespace).Get(vIngress.Name)
 		if errors.IsNotFound(err) {
 			if err := c.MultiClusterController.RequeueObject(clusterName, &ingList.Items[i]); err != nil {

--- a/virtualcluster/pkg/syncer/resources/ingress/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/ingress/checker_test.go
@@ -41,7 +41,7 @@ func TestIngressPatrol(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/ingress/dws.go
+++ b/virtualcluster/pkg/syncer/resources/ingress/dws.go
@@ -41,7 +41,7 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
 	klog.V(4).Infof("reconcile ingress %s/%s for cluster %s", request.Namespace, request.Name, request.ClusterName)
-	targetNamespace := conversion.ToSuperMasterNamespace(request.ClusterName, request.Namespace)
+	targetNamespace := conversion.ToSuperClusterNamespace(request.ClusterName, request.Namespace)
 	pIngress, err := c.ingressLister.Ingresses(targetNamespace).Get(request.Name)
 	pExists := true
 	if err != nil {
@@ -84,11 +84,7 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 }
 
 func (c *controller) reconcileIngressCreate(clusterName, targetNamespace, requestUID string, ingress *v1beta1.Ingress) error {
-	vcName, vcNS, _, err := c.MultiClusterController.GetOwnerInfo(clusterName)
-	if err != nil {
-		return err
-	}
-	newObj, err := conversion.BuildMetadata(clusterName, vcNS, vcName, targetNamespace, ingress)
+	newObj, err := c.Conversion().BuildSuperClusterObject(clusterName, ingress)
 	if err != nil {
 		return err
 	}

--- a/virtualcluster/pkg/syncer/resources/ingress/dws_test.go
+++ b/virtualcluster/pkg/syncer/resources/ingress/dws_test.go
@@ -75,7 +75,7 @@ func TestDWIngressCreation(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -165,7 +165,7 @@ func TestDWIngressDeletion(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper []runtime.Object
@@ -254,7 +254,7 @@ func TestDWIngressUpdate(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	nginx := "nginx"
 	spec1 := &v1beta1.IngressSpec{

--- a/virtualcluster/pkg/syncer/resources/ingress/uws_test.go
+++ b/virtualcluster/pkg/syncer/resources/ingress/uws_test.go
@@ -55,7 +55,7 @@ func TestUWIngress(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/namespace/checker.go
+++ b/virtualcluster/pkg/syncer/resources/namespace/checker.go
@@ -117,7 +117,7 @@ func (c *controller) PatrollerDo() {
 			vSet.Insert(differ.ClusterObject{
 				Object:       &vList.Items[i],
 				OwnerCluster: cluster,
-				Key:          conversion.ToSuperMasterNamespace(cluster, vList.Items[i].GetName()),
+				Key:          conversion.ToSuperClusterNamespace(cluster, vList.Items[i].GetName()),
 			})
 		}
 	}

--- a/virtualcluster/pkg/syncer/resources/namespace/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/namespace/checker_test.go
@@ -68,7 +68,7 @@ func TestNamespacePatrol(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 	utilconst.SuperClusterID = "test-super"
 
 	testcases := map[string]struct {

--- a/virtualcluster/pkg/syncer/resources/namespace/dws.go
+++ b/virtualcluster/pkg/syncer/resources/namespace/dws.go
@@ -43,7 +43,7 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 // The reconcile logic for tenant master namespace informer
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
 	klog.V(4).Infof("reconcile namespace %s for cluster %s", request.Name, request.ClusterName)
-	targetNamespace := conversion.ToSuperMasterNamespace(request.ClusterName, request.Name)
+	targetNamespace := conversion.ToSuperClusterNamespace(request.ClusterName, request.Name)
 	pNamespace, err := c.nsLister.Get(targetNamespace)
 	pExists := true
 	if err != nil {
@@ -86,12 +86,7 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 }
 
 func (c *controller) reconcileNamespaceCreate(clusterName, targetNamespace, requestUID string, vNamespace *v1.Namespace) error {
-	vcName, vcNamespace, vcUID, err := c.MultiClusterController.GetOwnerInfo(clusterName)
-	if err != nil {
-		return err
-	}
-
-	newObj, err := conversion.BuildSuperMasterNamespace(clusterName, vcName, vcNamespace, vcUID, vNamespace)
+	newObj, err := c.Conversion().BuildSuperClusterNamespace(clusterName, vNamespace)
 	if err != nil {
 		return err
 	}

--- a/virtualcluster/pkg/syncer/resources/namespace/dws_test.go
+++ b/virtualcluster/pkg/syncer/resources/namespace/dws_test.go
@@ -100,7 +100,7 @@ func TestDWNamespaceCreation(t *testing.T) {
 
 	defaultNSName := "default"
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	defaultSuperNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, defaultNSName)
+	defaultSuperNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, defaultNSName)
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -190,7 +190,7 @@ func TestDWNamespaceDeletion(t *testing.T) {
 
 	defaultNSName := "default"
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	defaultSuperNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, defaultNSName)
+	defaultSuperNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, defaultNSName)
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/persistentvolume/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolume/checker_test.go
@@ -136,7 +136,7 @@ func TestPVPatrol(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	pvSource1 := &v1.PersistentVolumeSource{
 		CSI: &v1.CSIPersistentVolumeSource{

--- a/virtualcluster/pkg/syncer/resources/persistentvolume/uws.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolume/uws.go
@@ -83,11 +83,7 @@ func (c *controller) BackPopulate(key string) error {
 				klog.Errorf("Cannot find the bound pvc %s/%s in tenant cluster %s for pv %v", vNamespace, pPVC.Name, clusterName, pPV)
 				return nil
 			}
-			vcName, vcNS, _, err := c.MultiClusterController.GetOwnerInfo(clusterName)
-			if err != nil {
-				return err
-			}
-			vPV := conversion.BuildVirtualPersistentVolume(clusterName, vcNS, vcName, pPV, vPVC)
+			vPV := conversion.BuildVirtualPersistentVolume(pPV, vPVC)
 			_, err = tenantClient.CoreV1().PersistentVolumes().Create(context.TODO(), vPV, metav1.CreateOptions{})
 			if err != nil {
 				return err

--- a/virtualcluster/pkg/syncer/resources/persistentvolume/uws_test.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolume/uws_test.go
@@ -46,7 +46,7 @@ func TestUWPVUpdate(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	pvSource1 := &v1.PersistentVolumeSource{
 		CSI: &v1.CSIPersistentVolumeSource{
@@ -206,7 +206,7 @@ func TestUWPVCreation(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/checker_test.go
@@ -72,7 +72,7 @@ func TestPVCPatrol(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/dws_test.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/dws_test.go
@@ -82,7 +82,7 @@ func TestDWPVCCreation(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -172,7 +172,7 @@ func TestDWPVCDeletion(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -261,7 +261,7 @@ func TestDWPVCUpdate(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	spec1 := &v1.PersistentVolumeClaimSpec{
 		AccessModes: []v1.PersistentVolumeAccessMode{

--- a/virtualcluster/pkg/syncer/resources/pod/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/pod/checker_test.go
@@ -87,7 +87,7 @@ func TestPodPatrol(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -342,7 +342,7 @@ func TestVNodeGC(t *testing.T) {
 		},
 	}
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 	statusReadyAndRunning := &v1.PodStatus{
 		Phase: "Running",
 		Conditions: []v1.PodCondition{

--- a/virtualcluster/pkg/syncer/resources/pod/dws_test.go
+++ b/virtualcluster/pkg/syncer/resources/pod/dws_test.go
@@ -117,7 +117,7 @@ func superPod(clusterKey, vcName, vcNamespace, name, namespace, uid string) *v1.
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: conversion.ToSuperMasterNamespace(clusterKey, namespace),
+			Namespace: conversion.ToSuperClusterNamespace(clusterKey, namespace),
 			Labels: map[string]string{
 				constants.LabelCluster:     clusterKey,
 				constants.LabelVCName:      vcName,
@@ -241,7 +241,7 @@ func TestDWPodCreation(t *testing.T) {
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
 	defaultVCName, defaultVCNamespace := testTenant.Name, testTenant.Namespace
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -329,8 +329,8 @@ func TestDWPodCreation(t *testing.T) {
 		},
 		"only a dns service": {
 			ExistingObjectInSuper: []runtime.Object{
-				superSecret("default-token-12345", conversion.ToSuperMasterNamespace(defaultClusterKey, "kube-system"), "s12345"),
-				superService(constants.TenantDNSServerServiceName, conversion.ToSuperMasterNamespace(defaultClusterKey, constants.TenantDNSServerNS), "12345", "192.168.0.10"),
+				superSecret("default-token-12345", conversion.ToSuperClusterNamespace(defaultClusterKey, "kube-system"), "s12345"),
+				superService(constants.TenantDNSServerServiceName, conversion.ToSuperClusterNamespace(defaultClusterKey, constants.TenantDNSServerNS), "12345", "192.168.0.10"),
 			},
 			ExistingObjectInTenant: []runtime.Object{
 				tenantPod("pod-1", "kube-system", "12345"),
@@ -433,7 +433,7 @@ func TestDWPodDeletion(t *testing.T) {
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
 	defaultVCName, defaultVCNamespace := testTenant.Name, testTenant.Namespace
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/pod/uws_test.go
+++ b/virtualcluster/pkg/syncer/resources/pod/uws_test.go
@@ -136,7 +136,7 @@ func TestUWPodUpdate(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -286,7 +286,7 @@ func TestUWPodDeletion(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/secret/checker.go
+++ b/virtualcluster/pkg/syncer/resources/secret/checker.go
@@ -130,7 +130,7 @@ func (c *controller) checkSecretOfTenantCluster(clusterName string) {
 	klog.V(4).Infof("check secrets consistency in cluster %s", clusterName)
 
 	for i, vSecret := range secretList.Items {
-		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vSecret.Namespace)
+		targetNamespace := conversion.ToSuperClusterNamespace(clusterName, vSecret.Namespace)
 
 		if vSecret.Type == v1.SecretTypeServiceAccountToken {
 			c.checkServiceAccountTokenTypeSecretOfTenantCluster(clusterName, targetNamespace, &secretList.Items[i])

--- a/virtualcluster/pkg/syncer/resources/secret/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/secret/checker_test.go
@@ -51,7 +51,7 @@ func TestSecretPatrol(t *testing.T) {
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
 	defaultVCName, defaultVCNamespace := testTenant.Name, testTenant.Namespace
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/secret/dws_test.go
+++ b/virtualcluster/pkg/syncer/resources/secret/dws_test.go
@@ -123,7 +123,7 @@ func TestDWSecretCreation(t *testing.T) {
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
 	defaultVCName, defaultVCNamespace := testTenant.Name, testTenant.Namespace
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -272,7 +272,7 @@ func TestDWSecretDeletion(t *testing.T) {
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
 	defaultVCName, defaultVCNamespace := testTenant.Name, testTenant.Namespace
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -365,7 +365,7 @@ func TestDWServiceAccountSecretDeletion(t *testing.T) {
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
 	defaultVCName, defaultVCNamespace := testTenant.Name, testTenant.Namespace
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper     []runtime.Object
@@ -465,7 +465,7 @@ func TestDWSecretUpdate(t *testing.T) {
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
 	defaultVCName, defaultVCNamespace := testTenant.Name, testTenant.Namespace
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/service/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/service/checker_test.go
@@ -42,7 +42,7 @@ func TestServicePatrol(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	spec1 := &v1.ServiceSpec{
 		Type:      v1.ServiceTypeClusterIP,

--- a/virtualcluster/pkg/syncer/resources/service/dws.go
+++ b/virtualcluster/pkg/syncer/resources/service/dws.go
@@ -41,7 +41,7 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
 	klog.V(4).Infof("reconcile service %s/%s for cluster %s", request.Namespace, request.Name, request.ClusterName)
-	targetNamespace := conversion.ToSuperMasterNamespace(request.ClusterName, request.Namespace)
+	targetNamespace := conversion.ToSuperClusterNamespace(request.ClusterName, request.Namespace)
 	pService, err := c.serviceLister.Services(targetNamespace).Get(request.Name)
 	pExists := true
 	if err != nil {
@@ -84,11 +84,7 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 }
 
 func (c *controller) reconcileServiceCreate(clusterName, targetNamespace, requestUID string, service *v1.Service) error {
-	vcName, vcNS, _, err := c.MultiClusterController.GetOwnerInfo(clusterName)
-	if err != nil {
-		return err
-	}
-	newObj, err := conversion.BuildMetadata(clusterName, vcNS, vcName, targetNamespace, service)
+	newObj, err := c.Conversion().BuildSuperClusterObject(clusterName, service)
 	if err != nil {
 		return err
 	}

--- a/virtualcluster/pkg/syncer/resources/service/dws_test.go
+++ b/virtualcluster/pkg/syncer/resources/service/dws_test.go
@@ -75,7 +75,7 @@ func TestDWServiceCreation(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -165,7 +165,7 @@ func TestDWServiceDeletion(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper []runtime.Object
@@ -254,7 +254,7 @@ func TestDWServiceUpdate(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	spec1 := &v1.ServiceSpec{
 		Type:      "ClusterIP",

--- a/virtualcluster/pkg/syncer/resources/service/uws_test.go
+++ b/virtualcluster/pkg/syncer/resources/service/uws_test.go
@@ -56,7 +56,7 @@ func TestUWService(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/serviceaccount/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/serviceaccount/checker_test.go
@@ -41,7 +41,7 @@ func TestServiceAccountPatrol(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/resources/serviceaccount/dws.go
+++ b/virtualcluster/pkg/syncer/resources/serviceaccount/dws.go
@@ -41,7 +41,7 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 // The reconcile logic for tenant master service account informer
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
 	klog.V(4).Infof("reconcile service account %s/%s for cluster %s", request.Namespace, request.Name, request.ClusterName)
-	targetNamespace := conversion.ToSuperMasterNamespace(request.ClusterName, request.Namespace)
+	targetNamespace := conversion.ToSuperClusterNamespace(request.ClusterName, request.Namespace)
 	pSa, err := c.saLister.ServiceAccounts(targetNamespace).Get(request.Name)
 	pExists := true
 	if err != nil {
@@ -85,11 +85,7 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 }
 
 func (c *controller) reconcileServiceAccountCreate(clusterName, targetNamespace, requestUID string, vSa *v1.ServiceAccount) error {
-	vcName, vcNS, _, err := c.MultiClusterController.GetOwnerInfo(clusterName)
-	if err != nil {
-		return err
-	}
-	newObj, err := conversion.BuildMetadata(clusterName, vcNS, vcName, targetNamespace, vSa)
+	newObj, err := c.Conversion().BuildSuperClusterObject(clusterName, vSa)
 	if err != nil {
 		return err
 	}

--- a/virtualcluster/pkg/syncer/resources/serviceaccount/dws_test.go
+++ b/virtualcluster/pkg/syncer/resources/serviceaccount/dws_test.go
@@ -79,7 +79,7 @@ func TestDWServiceAccountCreation(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -176,7 +176,7 @@ func TestDWServiceAccountDeletion(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
@@ -267,7 +267,7 @@ func TestDWServiceAccountUpdate(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
-	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object

--- a/virtualcluster/pkg/syncer/util/helper.go
+++ b/virtualcluster/pkg/syncer/util/helper.go
@@ -23,7 +23,7 @@ import (
 	mc "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/mccontroller"
 )
 
-func GetVirtualClusterObject(mc *mc.MultiClusterController, clustername string) (*v1alpha1.VirtualCluster, error) {
+func GetVirtualClusterObject(mc mc.MultiClusterInterface, clustername string) (*v1alpha1.VirtualCluster, error) {
 	obj, err := mc.GetClusterObject(clustername)
 	if err != nil {
 		return nil, fmt.Errorf("fail to obtain the virtualcluster object")

--- a/virtualcluster/pkg/syncer/util/test/runDWS.go
+++ b/virtualcluster/pkg/syncer/util/test/runDWS.go
@@ -84,10 +84,7 @@ func RunDownwardSync(
 		// Hence we don't have to populate the infomer cache.
 		tenantClient = fakeClient.NewFakeClient(existingObjectInTenant...)
 	}
-	tenantCluster, err := cluster.NewFakeTenantCluster(testTenant, tenantClientset, tenantClient)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error creating tenantCluster: %v", err)
-	}
+	tenantCluster := cluster.NewFakeTenantCluster(testTenant, tenantClientset, tenantClient)
 
 	// setup fake super cluster
 	superClient := fake.NewSimpleClientset()

--- a/virtualcluster/pkg/syncer/util/test/runPatrol.go
+++ b/virtualcluster/pkg/syncer/util/test/runPatrol.go
@@ -78,10 +78,7 @@ func RunPatrol(
 		// Hence we don't have to populate the infomer cache.
 		tenantClient = fakeClient.NewFakeClient(existingObjectInTenant...)
 	}
-	tenantCluster, err := cluster.NewFakeTenantCluster(testTenant, tenantClientset, tenantClient)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error creating tenantCluster: %v", err)
-	}
+	tenantCluster := cluster.NewFakeTenantCluster(testTenant, tenantClientset, tenantClient)
 
 	// setup fake super cluster
 	superClient := fake.NewSimpleClientset()

--- a/virtualcluster/pkg/syncer/util/test/runUWS.go
+++ b/virtualcluster/pkg/syncer/util/test/runUWS.go
@@ -76,10 +76,7 @@ func RunUpwardSync(
 		// Hence we don't have to populate the infomer cache.
 		tenantClient = fakeClient.NewFakeClient(existingObjectInTenant...)
 	}
-	tenantCluster, err := cluster.NewFakeTenantCluster(testTenant, tenantClientset, tenantClient)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error creating tenantCluster: %v", err)
-	}
+	tenantCluster := cluster.NewFakeTenantCluster(testTenant, tenantClientset, tenantClient)
 
 	// setup fake super cluster
 	superClient := fake.NewSimpleClientset()

--- a/virtualcluster/pkg/util/cluster/fake_cluster.go
+++ b/virtualcluster/pkg/util/cluster/fake_cluster.go
@@ -35,9 +35,7 @@ type fakeCluster struct {
 	fakeClient    client.Client
 }
 
-var _ mccontroller.ClusterInterface = &fakeCluster{}
-
-func NewFakeTenantCluster(vc *v1alpha1.VirtualCluster, fakeClientSet clientset.Interface, fakeClient client.Client) (*fakeCluster, error) {
+func NewFakeTenantCluster(vc *v1alpha1.VirtualCluster, fakeClientSet clientset.Interface, fakeClient client.Client) mccontroller.ClusterInterface {
 	cluster := &fakeCluster{
 		key:           conversion.ToClusterKey(vc),
 		vc:            vc,
@@ -45,7 +43,7 @@ func NewFakeTenantCluster(vc *v1alpha1.VirtualCluster, fakeClientSet clientset.I
 		fakeClient:    fakeClient,
 	}
 
-	return cluster, nil
+	return cluster
 }
 
 func (c *fakeCluster) GetClusterName() string {


### PR DESCRIPTION
Signed-off-by: zhuangqh <zhuangqhc@gmail.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

prevent tenant from using super cluster annotation/labels

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
