### PR TITLE
use namespace as kubeletclient cert cn because vn-agent expects that for kubectl exec

### DIFF
--- a/controlplane/nested/certificate/helpers.go
+++ b/controlplane/nested/certificate/helpers.go
@@ -75,10 +75,12 @@ func NewAPIServerCrtAndKey(ca *KeyPair, clusterName, clusterDomainArg, apiserver
 
 // NewAPIServerKubeletClientCertAndKey creates certificate for the apiservers to connect to the
 // kubelets securely, signed by the ca.
-func NewAPIServerKubeletClientCertAndKey(ca *KeyPair) (*KeyPair, error) {
+// A hack to use namespace as CN because vn-agent is using this CN to figure out the namespace in
+// super cluster for kubectl exec/log/port forward
+func NewAPIServerKubeletClientCertAndKey(ca *KeyPair, namespace string) (*KeyPair, error) {
 	config := &util.CertConfig{
 		Config: cert.Config{
-			CommonName:   "kube-apiserver-kubelet-client",
+			CommonName:   namespace,
 			Organization: []string{"system:masters"},
 			Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		},

--- a/controlplane/nested/controllers/nestedapiserver_controller.go
+++ b/controlplane/nested/controllers/nestedapiserver_controller.go
@@ -220,7 +220,7 @@ func (r *NestedAPIServerReconciler) createAPIServerClientCrts(ctx context.Contex
 		return err
 	}
 
-	kubeletKeyPair, err := certificate.NewAPIServerKubeletClientCertAndKey(&certificate.KeyPair{Cert: cacrt, Key: cakey})
+	kubeletKeyPair, err := certificate.NewAPIServerKubeletClientCertAndKey(&certificate.KeyPair{Cert: cacrt, Key: cakey}, cluster.Namespace)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION


<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

for kubectl exec/log/port forward, vn-agent needs to know the namespace in supercluster, currently it assumes the kubelet-client cert that virtual apiserver uses have the CN as the namespace, so add this hack to make it work. 

Also removed the flag 'kubelet-certificate-authority' in apiserver args because with that virtual apiserver is trying to validate the cert that vn-agent is using, which will fail because the cert doesn't have the pod IP as SAN. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
