### PR TITLE
Remove additional space in PROJECT file

### DIFF
--- a/controlplane/nested/PROJECT
+++ b/controlplane/nested/PROJECT
@@ -24,7 +24,7 @@ resources:
   version: v1alpha4
 - api:
     crdVersion: v1
-     namespaced: true
+    namespaced: true
   controller: true
   domain: cluster.x-k8s.io
   group: controlplane


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove wrongly added space in PROJECT file, because it affects generating new api with kubebuilder.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
