### PR TITLE
🌱 Remove ncdc from owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,7 +14,6 @@ aliases:
   cluster-api-maintainers:
   - justinsb
   - detiber
-  - ncdc
   - vincepri
   - CecileRobertMichon
   cluster-api-provider-nested-maintainers:


### PR DESCRIPTION
**What this PR does / why we need it**: I'm no longer working on Cluster API and would like to remove myself from the maintainers list.