### PR TITLE
🐛 VC-Syncer - remove check for optional secret Volumes on Pods

### DIFF
--- a/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/conversion"
@@ -222,7 +223,7 @@ func (c *controller) reconcilePodCreate(clusterName, targetNamespace, requestUID
 func (c *controller) findPodServiceAccountSecret(clusterName string, pPod, vPod *v1.Pod) (map[string]string, error) {
 	mountSecretSet := sets.NewString()
 	for _, volume := range vPod.Spec.Volumes {
-		if volume.Secret != nil {
+		if volume.Secret != nil && !pointer.BoolDeref(volume.Secret.Optional, false) {
 			mountSecretSet.Insert(volume.Secret.SecretName)
 		}
 	}

--- a/virtualcluster/pkg/syncer/resources/pod/dws_test.go
+++ b/virtualcluster/pkg/syncer/resources/pod/dws_test.go
@@ -81,6 +81,15 @@ func tenantPod(name, namespace, uid string) *v1.Pod {
 						},
 					},
 				},
+				{
+					Name: "i-do-not-exist-optional",
+					VolumeSource: v1.VolumeSource{
+						Secret: &v1.SecretVolumeSource{
+							SecretName: "i-do-not-exist",
+							Optional:   pointer.Bool(true),
+						},
+					},
+				},
 			},
 		},
 	}
@@ -170,6 +179,15 @@ func superPod(clusterKey, vcName, vcNamespace, name, namespace, uid string) *v1.
 					VolumeSource: v1.VolumeSource{
 						Secret: &v1.SecretVolumeSource{
 							SecretName: testSuperServiceAccountTokenSecretName,
+						},
+					},
+				},
+				{
+					Name: "i-do-not-exist-optional",
+					VolumeSource: v1.VolumeSource{
+						Secret: &v1.SecretVolumeSource{
+							SecretName: "i-do-not-exist",
+							Optional:   pointer.Bool(true),
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove a check for optional secrets in pod syncer. The pod resource syncer checks that all secrets defined in volumes in the pod spec exist in the virtual cluster. The intent is to ensure that service account tokens exist before the pod is scheduled. The minimal change is to only verify secrets that are marked as required. If it's optional, we remove it from the check.

We should confirm that ignoring optional doesn't compromise any of the security assumptions of the current model in terms of us making sure a service account token is properly synced before a pod is created.

We do already enforce this behavior with syncer optionally setting AutomountServiceAccountToken on the sync'd pods spec:
-  [DisableServiceAccountToken](https://github.com/kubernetes-sigs/cluster-api-provider-nested/blob/1eb78b9401490286579ac1aab0a51656e4547ae6/virtualcluster/pkg/syncer/apis/config/types.go#L51) 
- [syncer mutate using DisableServiceAccountToken](https://github.com/kubernetes-sigs/cluster-api-provider-nested/blob/2aa1c8cf8533419e790a56c2b68ba2fdfe04f9ae/virtualcluster/pkg/syncer/conversion/mutate.go#L391)

Note: The negative case is already covered with tests that verify that a ServiceAccount secret not existing will cause the syncer to fail. I'm open to adding to the tests if we feel it's useful, but my judgement was to not add them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #231 
