### PR TITLE
📖 Update documentation for DisableServiceAccountToken

### DIFF
--- a/virtualcluster/cmd/syncer/app/options/options.go
+++ b/virtualcluster/cmd/syncer/app/options/options.go
@@ -113,7 +113,7 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs.StringVar(&o.MetaClusterClientConnection.Kubeconfig, "meta-cluster-kubeconfig", o.MetaClusterClientConnection.Kubeconfig, "Path to kubeconfig file of the meta cluster. If it is not provided, the super cluster is used")
 	fs.BoolVar(&o.DeployOnMetaCluster, "deployment-on-meta", o.DeployOnMetaCluster, "Whether vc-syncer deploy on meta cluster")
 	fs.StringVar(&o.SyncerName, "syncer-name", o.SyncerName, "Syncer name (default vc).")
-	fs.BoolVar(&o.ComponentConfig.DisableServiceAccountToken, "disable-service-account-token", o.ComponentConfig.DisableServiceAccountToken, "DisableServiceAccountToken indicates whether disable service account token automatically mounted.")
+	fs.BoolVar(&o.ComponentConfig.DisableServiceAccountToken, "disable-service-account-token", o.ComponentConfig.DisableServiceAccountToken, "DisableServiceAccountToken indicates whether to disable super cluster service account tokens being auto generated and mounted in vc pods.")
 	fs.BoolVar(&o.ComponentConfig.DisablePodServiceLinks, "disable-service-links", o.ComponentConfig.DisablePodServiceLinks, "DisablePodServiceLinks indicates whether to disable the `EnableServiceLinks` field in pPod spec.")
 	fs.StringSliceVar(&o.ComponentConfig.DefaultOpaqueMetaDomains, "default-opaque-meta-domains", o.ComponentConfig.DefaultOpaqueMetaDomains, "DefaultOpaqueMetaDomains is the default opaque meta configuration for each Virtual Cluster.")
 	fs.StringSliceVar(&o.ComponentConfig.ExtraSyncingResources, "extra-syncing-resources", o.ComponentConfig.ExtraSyncingResources, "ExtraSyncingResources defines additional resources that need to be synced for each Virtual Cluster. (priorityclass, ingress, crd)")

--- a/virtualcluster/pkg/syncer/apis/config/types.go
+++ b/virtualcluster/pkg/syncer/apis/config/types.go
@@ -45,10 +45,11 @@ type SyncerConfiguration struct {
 	// ["aaa"]                  | ["foo=bar", "foo.kubernetes.io/foo=bar", "aaa/b=c"]
 	DefaultOpaqueMetaDomains []string
 
-	//ExtraSyncingResources defines additional resources that need to be synced for each Virtual CLuster
+	//ExtraSyncingResources defines additional resources that need to be synced for each Virtual Cluster
 	ExtraSyncingResources []string
 
-	// DisableServiceAccountToken indicates whether disable service account token automatically mounted.
+	// DisableServiceAccountToken indicates whether to disable super cluster service account tokens being auto generated
+	// and mounted in vc pods.
 	DisableServiceAccountToken bool
 
 	// DisablePodServiceLinks indicates whether to disable the `EnableServiceLinks` field in pPod spec.


### PR DESCRIPTION
**What this PR does / why we need it**:

DisableServiceAccountToken is ambiguous about the scope of ServiceAccountTokens that it is disabling(host vs tenant) and could lead to mis-configuration that could lead to security problems as a reasonable person might want service account tokens in their pods, but certainly not HostServiceAccountTokens in most cases.

Usage: 
- [set pod.Spec.AutomountServiceAccountToken](https://github.com/kubernetes-sigs/cluster-api-provider-nested/blob/2aa1c8cf8533419e790a56c2b68ba2fdfe04f9ae/virtualcluster/pkg/syncer/conversion/mutate.go#L391).
