### PR TITLE
🌱 Fix misspell in checker_scan_duration_seconds metric

### DIFF
--- a/virtualcluster/pkg/syncer/metrics/metrics.go
+++ b/virtualcluster/pkg/syncer/metrics/metrics.go
@@ -30,7 +30,7 @@ const (
 	PodOperationsDurationKey = "pod_operations_duration_seconds"
 	CheckerMissMatchKey      = "checker_missmatch_count"
 	CheckerRemedyKey         = "checker_remedy_count"
-	CheckerScanDurationKey   = "checker_scan_duaration_seconds"
+	CheckerScanDurationKey   = "checker_scan_duration_seconds"
 	DWSOperationCounterKey   = "dws_operations_total"
 	DWSOperationDurationKey  = "dws_operations_duration_seconds"
 	UWSOperationCounterKey   = "uws_operations_total"


### PR DESCRIPTION
**What this PR does / why we need it**: there is a misspelling in the Prometheus metric, which makes confusion and makes automation more difficult

