### PR TITLE
🌱 Add additionalPrinterColumns to VirtualCluster CRD

### DIFF
--- a/virtualcluster/config/crd/tenancy.x-k8s.io_virtualclusters.yaml
+++ b/virtualcluster/config/crd/tenancy.x-k8s.io_virtualclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: virtualclusters.tenancy.x-k8s.io
 spec:
@@ -18,7 +18,21 @@ spec:
     singular: virtualcluster
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.clusterVersionName
+      name: ClusterVersion
+      type: string
+    - jsonPath: .status.clusterNamespace
+      name: ClusterNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/virtualcluster/pkg/apis/tenancy/v1alpha1/virtualcluster_types.go
+++ b/virtualcluster/pkg/apis/tenancy/v1alpha1/virtualcluster_types.go
@@ -121,6 +121,10 @@ type ClusterCondition struct {
 
 // VirtualCluster is the Schema for the virtualclusters API
 // +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="ClusterVersion",type="string",JSONPath=".spec.clusterVersionName"
+// +kubebuilder:printcolumn:name="ClusterNamespace",type="string",JSONPath=".status.clusterNamespace",priority=1
 type VirtualCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

The current cluster listing is useless:

```
NAME         AGE
dev          24m
dev2         4s
```

We should improve CRD to add columns, like:
```
NAME          AGE     PHASE     CLUSTERVERSION
dev           3m58s   Running   v1-18
dev2          6m55s   Running   v1-19
```

and with `-o wide` 
```
NAME         AGE     PHASE     CLUSTERVERSION   CLUSTERNAMESPACE
dev          0s      Pending   v1-18            kcs-071942-dev
dev2         2m57s   Running   v1-19            kcs-a39dce-dev2
```


We should probably change https://github.com/kubernetes-sigs/cluster-api-provider-nested/blob/main/virtualcluster/Makefile#L114 to `output:crd:dir=./config/crd` as it do nothing now
