### PR TITLE
🌱 Configurable wait time on VirtualCluster Controller for control plane bring up

### DIFF
--- a/virtualcluster/cmd/manager/main.go
+++ b/virtualcluster/cmd/manager/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/apis"
@@ -50,6 +51,7 @@ func main() {
 		versionOpt              bool
 		disableStacktrace       bool
 		enableWebhook           bool
+		provisionerTimeout      time.Duration
 	)
 	flag.StringVar(&metricsAddr, "metrics-addr", ":0", "The address the metric endpoint binds to.")
 	flag.StringVar(&healthAddr, "health-addr", ":8080", "The address of the healthz/readyz endpoint binds to.")
@@ -64,6 +66,7 @@ func main() {
 	flag.BoolVar(&versionOpt, "version", false, "Print the version information")
 	flag.BoolVar(&disableStacktrace, "disable-stacktrace", false, "If set, the automatic stacktrace is disabled")
 	flag.BoolVar(&enableWebhook, "enable-webhook", false, "If set, the virtualcluster webhook is enabled")
+	flag.DurationVar(&provisionerTimeout, "provisioner-timeout", 10*time.Minute, "The timeout for provision control-plane statefulsets")
 
 	flag.Parse()
 
@@ -133,6 +136,7 @@ func main() {
 		Log:                     log.WithName("Controllers"),
 		Client:                  mgr.GetClient(),
 		ProvisionerName:         masterProvisioner,
+		ProvisionerTimeout:      provisionerTimeout,
 		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to register controllers to the manager")

--- a/virtualcluster/pkg/controller/controller.go
+++ b/virtualcluster/pkg/controller/controller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/controller/controllers"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -30,6 +32,7 @@ type Controllers struct {
 	Log                     logr.Logger
 	MaxConcurrentReconciles int
 	ProvisionerName         string
+	ProvisionerTimeout      time.Duration
 }
 
 // AddToManager adds all Controllers to the Manager
@@ -61,9 +64,10 @@ func (c *Controllers) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	if err := (&controllers.ReconcileVirtualCluster{
-		Client:          mgr.GetClient(),
-		Log:             c.Log.WithName("virtualcluster"),
-		ProvisionerName: c.ProvisionerName,
+		Client:             mgr.GetClient(),
+		Log:                c.Log.WithName("virtualcluster"),
+		ProvisionerName:    c.ProvisionerName,
+		ProvisionerTimeout: c.ProvisionerTimeout,
 	}).SetupWithManager(mgr, opts); err != nil {
 		return err
 	}

--- a/virtualcluster/pkg/controller/controllers/provisioner/provisioner_native.go
+++ b/virtualcluster/pkg/controller/controllers/provisioner/provisioner_native.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
@@ -42,21 +43,21 @@ import (
 const (
 	DefaultETCDPeerPort    = 2380
 	ComponentPollPeriodSec = 2
-	// timeout for components deployment
-	DeployTimeOutSec = 180
 )
 
 type ProvisionerNative struct {
 	client.Client
-	scheme *runtime.Scheme
-	Log    logr.Logger
+	scheme             *runtime.Scheme
+	Log                logr.Logger
+	ProvisionerTimeout time.Duration
 }
 
-func NewProvisionerNative(mgr manager.Manager, log logr.Logger) (*ProvisionerNative, error) {
+func NewProvisionerNative(mgr manager.Manager, log logr.Logger, provisionerTimeout time.Duration) (*ProvisionerNative, error) {
 	return &ProvisionerNative{
-		Client: mgr.GetClient(),
-		scheme: mgr.GetScheme(),
-		Log:    log.WithName("Native"),
+		Client:             mgr.GetClient(),
+		scheme:             mgr.GetScheme(),
+		Log:                log.WithName("Native"),
+		ProvisionerTimeout: provisionerTimeout,
 	}, nil
 }
 
@@ -200,7 +201,7 @@ func (mpn *ProvisionerNative) deployComponent(vc *tenancyv1alpha1.VirtualCluster
 	}
 
 	// wait for the statefuleset to be ready
-	err = kubeutil.WaitStatefulSetReady(mpn, ns, ssBdl.Name, DeployTimeOutSec, ComponentPollPeriodSec)
+	err = kubeutil.WaitStatefulSetReady(mpn, ns, ssBdl.Name, int64(mpn.ProvisionerTimeout/time.Second), ComponentPollPeriodSec)
 	if err != nil {
 		return err
 	}

--- a/virtualcluster/pkg/controller/controllers/suite_test.go
+++ b/virtualcluster/pkg/controller/controllers/suite_test.go
@@ -88,9 +88,10 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&ReconcileVirtualCluster{
-		Client:          mgr.GetClient(),
-		Log:             ctrl.Log.WithName("controllers").WithName("VirtualCluster"),
-		ProvisionerName: "native",
+		Client:             mgr.GetClient(),
+		Log:                ctrl.Log.WithName("controllers").WithName("VirtualCluster"),
+		ProvisionerName:    "native",
+		ProvisionerTimeout: 10 * time.Minute,
 	}).SetupWithManager(mgr, opts)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Today the manager will timeout after 180seconds and stop trying to deploy the control plane. This causes problems if someone is trying to create a cluster when there is super cluster issues happening.
The  PR allows to configure timeout with `--provisioner-timeout` flag for manager.
