### PR TITLE
🐛 Fix a corner case that cluster gets partially deleted and ends up w…

### DIFF
--- a/virtualcluster/pkg/syncer/syncer.go
+++ b/virtualcluster/pkg/syncer/syncer.go
@@ -331,6 +331,10 @@ func (s *Syncer) removeCluster(key string) {
 		// already deleted
 		return
 	}
+	if vc == nil {
+		delete(s.clusterSet, key)
+		return
+	}
 
 	vc.Stop()
 


### PR DESCRIPTION
…ith a nil cluster pointer

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
In some rare cases, cluster map in syncer got corrupted and returns nil cluster, and syncer cannot recover from it and keep crashing. Do a nil pointer check

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
