### PR TITLE
🐛 Fix cancel function nil problem

### DIFF
--- a/virtualcluster/pkg/util/cluster/cluster.go
+++ b/virtualcluster/pkg/util/cluster/cluster.go
@@ -294,14 +294,14 @@ func (c *Cluster) GetInformer(objectType client.Object) (cache.Informer, error) 
 // Start starts the Cluster's cache and blocks,
 // until context for the cache is cancelled.
 func (c *Cluster) Start() error {
+
+        ctx, cancel := context.WithCancel(c.context)
+        c.cancelContext = cancel
+
 	ca, err := c.getCache()
 	if err != nil {
 		return err
 	}
-
-	ctx, cancel := context.WithCancel(c.context)
-	c.cancelContext = cancel
-
 	return ca.Start(ctx)
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
When the cluster cache is not fully ready and getCache returns an error, the cancel function is not assigned. This will cause panic when the cluster removal process starts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
