### PR TITLE
🐛 When using ClusterIP based services we try to double create the service causing error messages

### DIFF
--- a/virtualcluster/pkg/controller/controllers/provisioner/provisioner_native.go
+++ b/virtualcluster/pkg/controller/controllers/provisioner/provisioner_native.go
@@ -188,7 +188,8 @@ func (mpn *ProvisionerNative) deployComponent(vc *tenancyv1alpha1.VirtualCluster
 			"namespace", ssBdl.StatefulSet.GetNamespace())
 	}
 
-	if ssBdl.Service != nil {
+	// skip apiserver clusterIP service creation as it is already created in CreateVirtualCluster()
+	if ssBdl.Service != nil && !(ssBdl.Name == "apiserver" && ssBdl.Service.Spec.Type == v1.ServiceTypeClusterIP) {
 		mpn.Log.Info("deploying Service for master component", "component", ssBdl.Name)
 		err = mpn.Create(context.TODO(), ssBdl.Service)
 		if err != nil {

--- a/virtualcluster/pkg/util/cluster/cluster.go
+++ b/virtualcluster/pkg/util/cluster/cluster.go
@@ -295,8 +295,8 @@ func (c *Cluster) GetInformer(objectType client.Object) (cache.Informer, error) 
 // until context for the cache is cancelled.
 func (c *Cluster) Start() error {
 
-        ctx, cancel := context.WithCancel(c.context)
-        c.cancelContext = cancel
+	ctx, cancel := context.WithCancel(c.context)
+	c.cancelContext = cancel
 
 	ca, err := c.getCache()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR skips the creation of clusterIP apiserver service when it must be already created in the CreateVirtualCluster method.

There is also a formatting change which probably accidentally was introduced earlier
