### PR TITLE
✨Enabling Metrics for vn-agent

### DIFF
--- a/virtualcluster/cmd/vn-agent/app/options/options.go
+++ b/virtualcluster/cmd/vn-agent/app/options/options.go
@@ -51,6 +51,9 @@ type ServerOption struct {
 	// Port is the vn-agent server listening on.
 	Port uint
 
+	// MetricsAddr is the address the metrics server is bound to.
+	MetricsAddr string
+
 	// Kubeconfig is the supercluster Kubeconfig to connect to
 	Kubeconfig string
 
@@ -89,6 +92,7 @@ func (o *Options) Flags() cliflag.NamedFlagSets {
 	serverFS.StringVar(&o.TLSPrivateKeyFile, "tls-private-key-file", o.TLSPrivateKeyFile, "TLSPrivateKeyFile is the file containing x509 private key matching tlsCertFile")
 	serverFS.StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 	serverFS.UintVar(&o.Port, "port", 10550, "Port is the server listening on")
+	serverFS.StringVar(&o.MetricsAddr, "metrics-addr", ":9100", "Bind address for the metrics server.")
 	serverFS.Var(cliflag.NewMapStringBool(&o.ServerOption.FeatureGates), "feature-gates", "A set of key=value pairs that describe featuregate gates for various features.")
 
 	kubeletFS := fss.FlagSet("kubelet")

--- a/virtualcluster/cmd/vn-agent/app/options/options.go
+++ b/virtualcluster/cmd/vn-agent/app/options/options.go
@@ -54,6 +54,9 @@ type ServerOption struct {
 	// MetricsAddr is the address the metrics server is bound to.
 	MetricsAddr string
 
+	// EnableMetrics is to enable metrics server.
+	EnableMetrics bool
+
 	// Kubeconfig is the supercluster Kubeconfig to connect to
 	Kubeconfig string
 
@@ -93,6 +96,7 @@ func (o *Options) Flags() cliflag.NamedFlagSets {
 	serverFS.StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 	serverFS.UintVar(&o.Port, "port", 10550, "Port is the server listening on")
 	serverFS.StringVar(&o.MetricsAddr, "metrics-addr", ":9100", "Bind address for the metrics server.")
+	serverFS.BoolVar(&o.EnableMetrics, "enable-metrics", true, "Enable metrics server.")
 	serverFS.Var(cliflag.NewMapStringBool(&o.ServerOption.FeatureGates), "feature-gates", "A set of key=value pairs that describe featuregate gates for various features.")
 
 	kubeletFS := fss.FlagSet("kubelet")

--- a/virtualcluster/cmd/vn-agent/app/server.go
+++ b/virtualcluster/cmd/vn-agent/app/server.go
@@ -140,18 +140,18 @@ func Run(c *config.Config, serverOption *options.ServerOption, stopCh <-chan str
 		healthz.InstallHandler(mux)
 		healthz.InstallLivezHandler(mux)
 		healthz.InstallReadyzHandler(mux)
-
 		klog.Fatal(http.ListenAndServe(":8080", mux))
 		errCh <- err
 	}()
 
-	klog.Infof("starting metrics server on %s", serverOption.MetricsAddr)
-
-	go func() {
-		// start metrics server
-		klog.Fatal(http.ListenAndServe(serverOption.MetricsAddr, server.NewMetricsServer()))
-		errCh <- err
-	}()
+	if serverOption.EnableMetrics {
+		klog.Infof("starting metrics server on %s", serverOption.MetricsAddr)
+		go func() {
+			// start metrics server
+			klog.Fatal(http.ListenAndServe(serverOption.MetricsAddr, server.NewMetricsServer()))
+			errCh <- err
+		}()
+	}
 
 	select {
 	case <-stopCh:

--- a/virtualcluster/cmd/vn-agent/app/server.go
+++ b/virtualcluster/cmd/vn-agent/app/server.go
@@ -20,12 +20,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"k8s.io/apiserver/pkg/server/healthz"
 	"net/http"
 	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"k8s.io/apiserver/pkg/server/healthz"
 	certutil "k8s.io/client-go/util/cert"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/cli/globalflag"
@@ -132,11 +132,24 @@ func Run(c *config.Config, serverOption *options.ServerOption, stopCh <-chan str
 		errCh <- err
 	}()
 
+	klog.Info("starting health api server on :8080")
+
 	go func() {
 		// start a health http server.
 		mux := http.NewServeMux()
 		healthz.InstallHandler(mux)
+		healthz.InstallLivezHandler(mux)
+		healthz.InstallReadyzHandler(mux)
+
 		klog.Fatal(http.ListenAndServe(":8080", mux))
+		errCh <- err
+	}()
+
+	klog.Infof("starting metrics server on %s", serverOption.MetricsAddr)
+
+	go func() {
+		// start metrics server
+		klog.Fatal(http.ListenAndServe(serverOption.MetricsAddr, server.NewMetricsServer()))
 		errCh <- err
 	}()
 

--- a/virtualcluster/pkg/vn-agent/server/metrics.go
+++ b/virtualcluster/pkg/vn-agent/server/metrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/virtualcluster/pkg/vn-agent/server/metrics.go
+++ b/virtualcluster/pkg/vn-agent/server/metrics.go
@@ -19,7 +19,6 @@ package server
 import (
 	"fmt"
 	"net/http"
-	"net/http/pprof"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -75,8 +74,7 @@ var (
 
 var registerMetrics sync.Once
 
-// Register all metrics.
-func Register() {
+func register() {
 	registerMetrics.Do(func() {
 		prometheus.MustRegister(counterForTenantsAndNamespace,
 			failureCounter,
@@ -88,14 +86,9 @@ func Register() {
 
 // NewMetricsServer initializes and configures the MetricsServer.
 func NewMetricsServer() *http.ServeMux {
-	Register()
+	register()
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	return mux
 }
 

--- a/virtualcluster/pkg/vn-agent/server/metrics.go
+++ b/virtualcluster/pkg/vn-agent/server/metrics.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	resourceVNAgentSubsystem             = "vn_agent"
+	metricNameFailureCounterForNamespace = "counter_for_tenant_namespace"
+	metricNameFailureCounterForTenants   = "counter_for_tenant_failure"
+	metricNameInFlightRequests           = "in_flight_requests"
+	metricNameTotalRequests              = "total_requests"
+	metricNameRequestLatency             = "request_latencies"
+	errorProxyingRequest                 = "error_proxying_request"
+	errorTranslatingPath                 = "error_translating_path"
+)
+
+var (
+	counterForTenantsAndNamespace = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: resourceVNAgentSubsystem,
+		Name:      metricNameFailureCounterForNamespace,
+		Help:      "counter for api operations by tenants",
+	}, []string{"host", "action", "tenantName", "tenantNamespace", "responseCode"})
+
+	failureCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: resourceVNAgentSubsystem,
+		Name:      metricNameFailureCounterForTenants,
+		Help:      "counter for failure api operations by tenants",
+	}, []string{"host", "action", "tenantName", "tenantNamespace", "reason"})
+
+	inFlightRequests = prometheus.NewGauge(prometheus.GaugeOpts{
+		Subsystem: resourceVNAgentSubsystem,
+		Name:      metricNameInFlightRequests,
+		Help:      "inflight requests",
+	})
+
+	totalRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: resourceVNAgentSubsystem,
+		Name:      metricNameTotalRequests,
+		Help:      "total requests",
+	}, []string{"code", "method"})
+
+	requestLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: resourceVNAgentSubsystem,
+			Name:      metricNameRequestLatency,
+			Help:      "request latencies",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{},
+	)
+)
+
+var registerMetrics sync.Once
+
+// Register all metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		prometheus.MustRegister(counterForTenantsAndNamespace,
+			failureCounter,
+			inFlightRequests,
+			totalRequests,
+			requestLatency)
+	})
+}
+
+// NewMetricsServer initializes and configures the MetricsServer.
+func NewMetricsServer() *http.ServeMux {
+	Register()
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	return mux
+}
+
+func getRoundTripper(transport http.RoundTripper,
+	host, tenantName, action, podNamespace string) http.RoundTripper {
+	return promhttp.InstrumentRoundTripperInFlight(inFlightRequests,
+		promhttp.InstrumentRoundTripperCounter(totalRequests,
+			promhttp.InstrumentRoundTripperDuration(requestLatency, agentRoundTripper{
+				nextRoundTripper: transport,
+				tenantName:       tenantName,
+				host:             host,
+				action:           action,
+				podNamespace:     podNamespace,
+			})))
+}
+
+type agentRoundTripper struct {
+	nextRoundTripper http.RoundTripper
+	tenantName       string
+	host             string
+	action           string
+	podNamespace     string
+}
+
+func (art agentRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	response, err := art.nextRoundTripper.RoundTrip(r)
+	if err == nil {
+		counterForTenantsAndNamespace.
+			WithLabelValues(art.host, art.action, art.tenantName, art.podNamespace, fmt.Sprint(response.StatusCode)).
+			Inc()
+	}
+	return response, err
+}

--- a/virtualcluster/pkg/vn-agent/server/route.go
+++ b/virtualcluster/pkg/vn-agent/server/route.go
@@ -17,12 +17,14 @@ limitations under the License.
 package server
 
 import (
-	"net/http"
-
 	"github.com/emicklei/go-restful"
+
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/klog/v2"
+
+	"net/http"
+	"strings"
 )
 
 // InstallHandlers set router and handlers.
@@ -115,48 +117,76 @@ func (s *Server) InstallHandlers() {
 func (s *Server) proxy(req *restful.Request, resp *restful.Response) {
 	klog.V(4).Infof("request %+v", req.Request.URL)
 
+	var host string
+
 	// there must be a peer certificate in the tls connection
 	if req.Request.TLS == nil || len(req.Request.TLS.PeerCertificates) == 0 {
 		resp.ResponseWriter.WriteHeader(http.StatusForbidden)
 		return
 	}
 
+	action, podNamespace := extractFromPath(req)
+	tenantName := req.Request.TLS.PeerCertificates[0].Subject.CommonName
+
 	if s.config.KubeletClientCert != nil {
 		klog.Info("will forward request to kubelet")
+		host = s.config.KubeletServerHost
 		// forward request to kubelet
-		req.Request.URL.Host = s.config.KubeletServerHost
+		req.Request.URL.Host = host
 		req.Request.URL.Scheme = "https"
-
-		tenantName := req.Request.TLS.PeerCertificates[0].Subject.CommonName
 		TranslatePath(req, tenantName)
-
-		klog.V(4).Infof("request after translate %+v", req.Request.URL)
 	} else {
 		klog.Info("will forward request to super apiserver")
+		host = s.superAPIServerAddress.Host
 		// forward request to super apiserver
-		tenantName := req.Request.TLS.PeerCertificates[0].Subject.CommonName
 		err := TranslatePathForSuper(req, tenantName)
 		if err != nil {
 			klog.Errorf("fail to translate url path for super master: %s", err)
 			resp.ResponseWriter.WriteHeader(http.StatusNotFound)
 			resp.ResponseWriter.Write([]byte(err.Error()))
+			failureCounter.WithLabelValues(
+				s.superAPIServerAddress.Host, action, tenantName, podNamespace, errorTranslatingPath).
+				Inc()
 			return
 		}
 		klog.V(4).Infof("request after translate %+v", req.Request.URL)
 
 		// mutate the request, i.e., replacing the dst, add bearer token header
-		req.Request.URL.Host = s.superAPIServerAddress.Host
+		req.Request.URL.Host = host
 		req.Request.URL.Scheme = "https"
 		req.Request.Header.Add("Authorization", "Bearer "+s.restConfig.BearerToken)
 	}
 
-	handler := proxy.NewUpgradeAwareHandler(req.Request.URL, s.transport /*transport*/, false /*wrapTransport*/, httpstream.IsUpgradeRequest(req.Request) /*upgradeRequired*/, &responder{})
+	roundTripper := getRoundTripper(s.transport, host, tenantName, action, podNamespace)
+
+	handler := proxy.NewUpgradeAwareHandler(req.Request.URL, roundTripper /*transport*/, false, /*wrapTransport*/
+		httpstream.IsUpgradeRequest(req.Request) /*upgradeRequired*/, &responder{
+			action:       action,
+			tenantName:   tenantName,
+			podNamespace: podNamespace,
+			host:         host,
+		})
+	handler.UpgradeTransport = proxy.NewUpgradeRequestRoundTripper(s.transport, roundTripper)
 	handler.ServeHTTP(resp.ResponseWriter, req.Request)
 }
 
-type responder struct{}
+type responder struct {
+	action       string
+	tenantName   string
+	podNamespace string
+	host         string
+}
 
 func (r *responder) Error(w http.ResponseWriter, req *http.Request, err error) {
+	failureCounter.WithLabelValues(r.host, r.action, r.tenantName,
+		r.podNamespace, errorProxyingRequest).
+		Inc()
 	klog.Errorf("Error while proxying request: %v", err)
 	http.Error(w, err.Error(), http.StatusInternalServerError)
+}
+
+func extractFromPath(req *restful.Request) (string, string) {
+	action := strings.Split(req.Request.URL.Path[1:], "/")[0]
+	pathParas := req.PathParameters()
+	return action, pathParas["podNamespace"]
 }

--- a/virtualcluster/pkg/vn-agent/server/server.go
+++ b/virtualcluster/pkg/vn-agent/server/server.go
@@ -39,6 +39,7 @@ type Server struct {
 	transport             *http.Transport
 	superAPIServerAddress *url.URL
 	restConfig            *rest.Config
+	enableMetrics         bool
 }
 
 // ServeHTTP responds to HTTP requests on the vn-agent.
@@ -55,8 +56,9 @@ func NewServer(cfg *config.Config, serverOption *options.ServerOption) (*Server,
 	cfg.KubeletServerHost = u.Host
 
 	server := &Server{
-		restfulCont: restful.NewContainer(),
-		config:      cfg,
+		restfulCont:   restful.NewContainer(),
+		config:        cfg,
+		enableMetrics: serverOption.EnableMetrics,
 	}
 
 	server.InstallHandlers()


### PR DESCRIPTION
 **What this PR does / why we need it**:

The pr enabled metrics server for vn-agent instrumenting all the API Calls to super API Server or Kubelet and counting all the API Calls with respect to host, tenantName, tenantNamespace, action and responseCode.

**Which issue(s) this PR fixes**
Fixes #251 
