### PR TITLE
✨ Supporting Super Cluster Timeout Overrides

### DIFF
--- a/virtualcluster/pkg/syncer/apis/config/types.go
+++ b/virtualcluster/pkg/syncer/apis/config/types.go
@@ -70,6 +70,9 @@ type SyncerConfiguration struct {
 
 	// Super cluster rest config
 	RestConfig *rest.Config
+
+	// The maximum length of time to wait before giving up on a server request. A value of "" means use default.
+	Timeout string
 }
 
 // SyncerLeaderElectionConfiguration expands LeaderElectionConfiguration


### PR DESCRIPTION
**What this PR does / why we need it**:
The default hardcoded 30 second timeout for the super cluster isn't enough under some scenarios, this allows that to be additionally supplied from a CLI flag but still uses the standard default if not supplied.

Signed-off-by: Chris Hein <me@chrishein.com>