### PR TITLE
vc-syncer: set HealthCheckNodePort to zero before sync service to sup…

### DIFF
--- a/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/virtualcluster/pkg/syncer/conversion/equality.go
@@ -656,6 +656,7 @@ func (e vcEquality) CheckIngressEquality(pObj, vObj *v1beta1extensions.Ingress) 
 
 func filterNodePort(svc *v1.Service) *v1.ServiceSpec {
 	specClone := svc.Spec.DeepCopy()
+	specClone.HealthCheckNodePort = 0
 	for i, _ := range specClone.Ports {
 		specClone.Ports[i].NodePort = 0
 	}
@@ -691,6 +692,7 @@ func (e vcEquality) CheckServiceEquality(pObj, vObj *v1.Service) *v1.Service {
 			updated.Spec.Ports[i].NodePort = pObj.Spec.Ports[j].NodePort
 			j++
 		}
+		updated.Spec.HealthCheckNodePort = pObj.Spec.HealthCheckNodePort
 	}
 	return updated
 }

--- a/virtualcluster/pkg/syncer/conversion/mutate.go
+++ b/virtualcluster/pkg/syncer/conversion/mutate.go
@@ -456,6 +456,7 @@ func (s *serviceMutator) Mutate(vService *v1.Service) {
 		s.pService.SetAnnotations(anno)
 		s.pService.Spec.ClusterIP = ""
 	}
+	s.pService.Spec.HealthCheckNodePort = 0
 	for i := range s.pService.Spec.Ports {
 		s.pService.Spec.Ports[i].NodePort = 0
 	}


### PR DESCRIPTION
…er cluster

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The current logic for sync service miss setting service.spec.HealthCheckNodePort to zero, which may lead to cause port conflict.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
