### PR TITLE
Add DnsOption Flag to allow user to have customized resolve.conf

### DIFF
--- a/controlplane/nested/main.go
+++ b/controlplane/nested/main.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
         "k8s.io/component-base/logs"
 	"k8s.io/klog/v2/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"

--- a/controlplane/nested/main.go
+++ b/controlplane/nested/main.go
@@ -28,6 +28,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
+        "k8s.io/component-base/logs"
 	"k8s.io/klog/v2/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/feature"
@@ -58,8 +59,6 @@ var (
 )
 
 func init() {
-	klog.InitFlags(nil)
-
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
 	utilruntime.Must(controlplanev1alpha4.AddToScheme(scheme))
@@ -100,6 +99,9 @@ func InitFlags(fs *pflag.FlagSet) {
 }
 
 func main() {
+        logs.InitLogs()
+        defer logs.FlushLogs()
+
 	rand.Seed(time.Now().UnixNano())
 
 	InitFlags(pflag.CommandLine)

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.21.9
 	k8s.io/apimachinery v0.21.9
+	k8s.io/component-base v0.21.9
 	k8s.io/client-go v0.21.9
-	k8s.io/component-base v0.21.2 // indirect
 	k8s.io/klog/v2 v2.10.0
 	sigs.k8s.io/cluster-api v0.4.0
 	sigs.k8s.io/controller-runtime v0.9.3

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/api v0.21.9
 	k8s.io/apimachinery v0.21.9
 	k8s.io/client-go v0.21.9
+	k8s.io/component-base v0.21.2 // indirect
 	k8s.io/klog/v2 v2.10.0
 	sigs.k8s.io/cluster-api v0.4.0
 	sigs.k8s.io/controller-runtime v0.9.3

--- a/go.sum
+++ b/go.sum
@@ -1177,6 +1177,8 @@ k8s.io/component-base v0.17.2/go.mod h1:zMPW3g5aH7cHJpKYQ/ZsGMcgbsA/VyhEugF3QT1a
 k8s.io/component-base v0.21.1/go.mod h1:NgzFZ2qu4m1juby4TnrmpR8adRk6ka62YdH5DkIIyKA=
 k8s.io/component-base v0.21.2 h1:EsnmFFoJ86cEywC0DoIkAUiEV6fjgauNugiw1lmIjs4=
 k8s.io/component-base v0.21.2/go.mod h1:9lvmIThzdlrJj5Hp8Z/TOgIkdfsNARQ1pT+3PByuiuc=
+k8s.io/component-base v0.21.9 h1:68NPBPdh00yJ1xg4R1iD3QR7J63WKVBmJ9xquWRzWBM=
+k8s.io/component-base v0.21.9/go.mod h1:WcHNBw5qfjQGjQpOgmOALmQArmxocivbDSuYZxyWvK8=
 k8s.io/component-helpers v0.21.1/go.mod h1:FtC1flbiQlosHQrLrRUulnKxE4ajgWCGy/67fT2GRlQ=
 k8s.io/component-helpers v0.21.2/go.mod h1:DbyFt/A0p6Cv+R5+QOGSJ5f5t4xDfI8Yb89a57DgJlQ=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
         "k8s.io/component-base/logs"
-        "k8s.io/klog/v2"
+        klog "k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/feature"

--- a/main.go
+++ b/main.go
@@ -27,7 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog/v2"
+        "k8s.io/component-base/logs"
+        "k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/feature"
@@ -59,8 +60,6 @@ var (
 )
 
 func init() {
-	klog.InitFlags(nil)
-
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
 	utilruntime.Must(controlplanev1.AddToScheme(scheme))
@@ -104,6 +103,9 @@ func InitFlags(fs *pflag.FlagSet) {
 }
 
 func main() {
+        logs.InitLogs()
+        defer logs.FlushLogs()
+
 	rand.Seed(time.Now().UnixNano())
 
 	InitFlags(pflag.CommandLine)

--- a/virtualcluster/cmd/syncer/app/options/options.go
+++ b/virtualcluster/cmd/syncer/app/options/options.go
@@ -19,6 +19,7 @@ package options
 import (
 	"fmt"
 	"io/ioutil"
+	"k8s.io/utils/pointer"
 	"os"
 	"time"
 
@@ -67,6 +68,7 @@ type ResourceSyncerOptions struct {
 	Port                string
 	CertFile            string
 	KeyFile             string
+	DnsOptions          map[string]string
 }
 
 // NewResourceSyncerOptions creates a new resource syncer with a default config.
@@ -101,6 +103,9 @@ func NewResourceSyncerOptions() (*ResourceSyncerOptions, error) {
 		Port:       "80",
 		CertFile:   "",
 		KeyFile:    "",
+		DnsOptions: map[string]string{
+			"ndots": "5",
+		},
 	}, nil
 }
 
@@ -122,6 +127,7 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs.Var(cliflag.NewMapStringBool(&o.ComponentConfig.FeatureGates), "feature-gates", "A set of key=value pairs that describe featuregate gates for various features.")
 	fs.Int32Var(&o.ComponentConfig.VNAgentPort, "vn-agent-port", 10550, "Port the vn-agent listens on")
 	fs.StringVar(&o.ComponentConfig.VNAgentNamespacedName, "vn-agent-namespace-name", "vc-manager/vn-agent", "Namespace/Name of the vn-agent running in cluster, used for VNodeProviderService")
+	fs.Var(cliflag.NewMapStringString(&o.DnsOptions), "dns-options", "DnsOptions is the default DNS options attached to each pod")
 
 	serverFlags := fss.FlagSet("metricsServer")
 	serverFlags.StringVar(&o.Address, "address", o.Address, "The server address.")
@@ -236,6 +242,7 @@ func (o *ResourceSyncerOptions) Config() (*syncerappconfig.Config, error) {
 		return nil, err
 	}
 	c.ComponentConfig.RestConfig = superRestConfig
+	c.ComponentConfig.DNSOptions = dnsOptionsConvert(o.DnsOptions)
 	c.VirtualClusterClient = virtualClusterClient
 	c.VirtualClusterInformer = vcinformers.NewSharedInformerFactory(virtualClusterClient, 0).Tenancy().V1alpha1().VirtualClusters()
 	c.MetaClusterClient = metaClusterClient
@@ -361,4 +368,12 @@ func getClientConfig(config componentbaseconfig.ClientConnectionConfiguration, m
 	}
 
 	return restConfig, nil
+}
+
+func dnsOptionsConvert(dnsoptions map[string]string) []corev1.PodDNSConfigOption {
+	podDnsOptions := []corev1.PodDNSConfigOption{}
+	for k, v := range dnsoptions {
+		podDnsOptions = append(podDnsOptions, corev1.PodDNSConfigOption{Name: k, Value: pointer.StringPtr(v)})
+	}
+	return podDnsOptions
 }

--- a/virtualcluster/pkg/syncer/apis/config/types.go
+++ b/virtualcluster/pkg/syncer/apis/config/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	componentbaseconfig "k8s.io/component-base/config"
@@ -73,6 +74,9 @@ type SyncerConfiguration struct {
 
 	// The maximum length of time to wait before giving up on a server request. A value of "" means use default.
 	Timeout string
+
+	// The DnsOptions are the DNS options in resolv.conf that is attached to pod
+	DNSOptions []v1.PodDNSConfigOption
 }
 
 // SyncerLeaderElectionConfiguration expands LeaderElectionConfiguration

--- a/virtualcluster/pkg/syncer/conversion/mutate.go
+++ b/virtualcluster/pkg/syncer/conversion/mutate.go
@@ -112,7 +112,7 @@ func mutateWeightedPodAffinityTerms(weightedTerms []v1.WeightedPodAffinityTerm, 
 	}
 }
 
-func PodMutateDefault(vPod *v1.Pod, saSecretMap map[string]string, services []*v1.Service, nameServer string) PodMutator {
+func PodMutateDefault(vPod *v1.Pod, saSecretMap map[string]string, services []*v1.Service, nameServer string, dnsOption []v1.PodDNSConfigOption) PodMutator {
 	return func(p *podMutateCtx) error {
 		p.pPod.Status = v1.PodStatus{}
 		p.pPod.Spec.NodeName = ""
@@ -173,7 +173,7 @@ func PodMutateDefault(vPod *v1.Pod, saSecretMap map[string]string, services []*v
 		if err != nil {
 			return err
 		}
-		mutateDNSConfig(p, vPod, vc.Spec.ClusterDomain, nameServer)
+		mutateDNSConfig(p, vPod, vc.Spec.ClusterDomain, nameServer, dnsOption)
 
 		// FIXME(zhuangqh): how to support pod subdomain.
 		if p.pPod.Spec.Subdomain != "" {
@@ -287,7 +287,7 @@ func getServiceEnvVarMap(ns, cluster string, enableServiceLinks *bool, services 
 	return apiServerService, m
 }
 
-func mutateDNSConfig(p *podMutateCtx, vPod *v1.Pod, clusterDomain, nameServer string) {
+func mutateDNSConfig(p *podMutateCtx, vPod *v1.Pod, clusterDomain, nameServer string, dnsOption []v1.PodDNSConfigOption) {
 	// If the TenantAllowDNSPolicy feature gate is added AND if the vPod labels include
 	// tenancy.x-k8s.io/disable.dnsPolicyMutation: "true" then we should return without
 	// mutating the config. This is to allow special pods like coredns to use the
@@ -304,11 +304,11 @@ func mutateDNSConfig(p *podMutateCtx, vPod *v1.Pod, clusterDomain, nameServer st
 	case v1.DNSNone:
 		return
 	case v1.DNSClusterFirstWithHostNet:
-		mutateClusterFirstDNS(p, vPod, clusterDomain, nameServer)
+		mutateClusterFirstDNS(p, vPod, clusterDomain, nameServer, dnsOption)
 		return
 	case v1.DNSClusterFirst:
 		if !p.pPod.Spec.HostNetwork {
-			mutateClusterFirstDNS(p, vPod, clusterDomain, nameServer)
+			mutateClusterFirstDNS(p, vPod, clusterDomain, nameServer, dnsOption)
 			return
 		}
 		// Fallback to DNSDefault for pod on hostnetwork.
@@ -318,7 +318,7 @@ func mutateDNSConfig(p *podMutateCtx, vPod *v1.Pod, clusterDomain, nameServer st
 	}
 }
 
-func mutateClusterFirstDNS(p *podMutateCtx, vPod *v1.Pod, clusterDomain, nameServer string) {
+func mutateClusterFirstDNS(p *podMutateCtx, vPod *v1.Pod, clusterDomain, nameServer string, dnsOption []v1.PodDNSConfigOption) {
 	if nameServer == "" {
 		klog.Infof("vc %s does not have ClusterDNS IP configured and cannot create Pod using %q policy. Falling back to %q policy.",
 			p.clusterName, v1.DNSClusterFirst, v1.DNSDefault)
@@ -333,12 +333,7 @@ func mutateClusterFirstDNS(p *podMutateCtx, vPod *v1.Pod, clusterDomain, nameSer
 	// itself.
 	dnsConfig := &v1.PodDNSConfig{
 		Nameservers: []string{nameServer},
-		Options: []v1.PodDNSConfigOption{
-			{
-				Name:  "ndots",
-				Value: pointer.StringPtr("5"),
-			},
-		},
+		Options:     dnsOption,
 	}
 
 	if clusterDomain != "" {

--- a/virtualcluster/pkg/syncer/conversion/mutate_test.go
+++ b/virtualcluster/pkg/syncer/conversion/mutate_test.go
@@ -274,6 +274,9 @@ func Test_mutateDNSConfig(t *testing.T) {
 	}
 	defaultOptions := []v1.PodDNSConfigOption{
 		v1.PodDNSConfigOption{
+			Name: "use-vc",
+		},
+		v1.PodDNSConfigOption{
 			Name:  "ndots",
 			Value: pointer.StringPtr("5"),
 		},
@@ -288,6 +291,7 @@ func Test_mutateDNSConfig(t *testing.T) {
 		vPod          *v1.Pod
 		clusterDomain string
 		nameServer    string
+		dnsoptions    []v1.PodDNSConfigOption
 	}
 	tests := []struct {
 		name              string
@@ -302,6 +306,15 @@ func Test_mutateDNSConfig(t *testing.T) {
 				p:          podMutateCtxFunc(v1.DNSNone, nil, false),
 				vPod:       newPod(),
 				nameServer: "0.0.0.0",
+				dnsoptions: []v1.PodDNSConfigOption{
+					v1.PodDNSConfigOption{
+						Name: "use-vc",
+					},
+					v1.PodDNSConfigOption{
+						Name:  "ndots",
+						Value: pointer.StringPtr("5"),
+					},
+				},
 			},
 			expectedDNSPolicy: &dnsNone,
 		},
@@ -313,6 +326,15 @@ func Test_mutateDNSConfig(t *testing.T) {
 				}, false),
 				vPod:       newPod(),
 				nameServer: "0.0.0.0",
+				dnsoptions: []v1.PodDNSConfigOption{
+					v1.PodDNSConfigOption{
+						Name: "use-vc",
+					},
+					v1.PodDNSConfigOption{
+						Name:  "ndots",
+						Value: pointer.StringPtr("5"),
+					},
+				},
 			},
 			expectedDNSPolicy: &dnsNone,
 			expectedDNSConfig: &v1.PodDNSConfig{
@@ -325,6 +347,15 @@ func Test_mutateDNSConfig(t *testing.T) {
 				p:          podMutateCtxFunc(v1.DNSClusterFirstWithHostNet, nil, false),
 				vPod:       newPod(),
 				nameServer: "0.0.0.0",
+				dnsoptions: []v1.PodDNSConfigOption{
+					v1.PodDNSConfigOption{
+						Name: "use-vc",
+					},
+					v1.PodDNSConfigOption{
+						Name:  "ndots",
+						Value: pointer.StringPtr("5"),
+					},
+				},
 			},
 			expectedDNSPolicy: &dnsNone,
 			expectedDNSConfig: &v1.PodDNSConfig{
@@ -338,6 +369,15 @@ func Test_mutateDNSConfig(t *testing.T) {
 				p:          podMutateCtxFunc(v1.DNSClusterFirst, nil, false),
 				vPod:       newPod(),
 				nameServer: "0.0.0.0",
+				dnsoptions: []v1.PodDNSConfigOption{
+					v1.PodDNSConfigOption{
+						Name: "use-vc",
+					},
+					v1.PodDNSConfigOption{
+						Name:  "ndots",
+						Value: pointer.StringPtr("5"),
+					},
+				},
 			},
 			expectedDNSPolicy: &dnsNone,
 			expectedDNSConfig: &v1.PodDNSConfig{
@@ -350,31 +390,24 @@ func Test_mutateDNSConfig(t *testing.T) {
 			args: args{
 				p: podMutateCtxFunc(v1.DNSClusterFirst, &v1.PodDNSConfig{
 					Nameservers: []string{"127.0.0.1"},
-					Options: []v1.PodDNSConfigOption{
-						v1.PodDNSConfigOption{
-							Name: "use-vc",
-						},
-						v1.PodDNSConfigOption{
-							Name:  "ndots",
-							Value: pointer.StringPtr("2"),
-						},
-					},
+					Options:     defaultOptions,
 				}, false),
 				vPod:       newPod(),
 				nameServer: "0.0.0.0",
+				dnsoptions: []v1.PodDNSConfigOption{
+					v1.PodDNSConfigOption{
+						Name: "use-vc",
+					},
+					v1.PodDNSConfigOption{
+						Name:  "ndots",
+						Value: pointer.StringPtr("5"),
+					},
+				},
 			},
 			expectedDNSPolicy: &dnsNone,
 			expectedDNSConfig: &v1.PodDNSConfig{
 				Nameservers: []string{"0.0.0.0", "127.0.0.1"},
-				Options: []v1.PodDNSConfigOption{
-					v1.PodDNSConfigOption{
-						Name:  "ndots",
-						Value: pointer.StringPtr("2"),
-					},
-					v1.PodDNSConfigOption{
-						Name: "use-vc",
-					},
-				},
+				Options:     defaultOptions,
 			},
 		},
 		{
@@ -383,6 +416,15 @@ func Test_mutateDNSConfig(t *testing.T) {
 				p:          podMutateCtxFunc(v1.DNSClusterFirst, nil, true),
 				vPod:       newPod(),
 				nameServer: "0.0.0.0",
+				dnsoptions: []v1.PodDNSConfigOption{
+					v1.PodDNSConfigOption{
+						Name: "use-vc",
+					},
+					v1.PodDNSConfigOption{
+						Name:  "ndots",
+						Value: pointer.StringPtr("5"),
+					},
+				},
 			},
 			expectedDNSPolicy: &dnsClusterFirst,
 			expectedDNSConfig: nil,
@@ -393,6 +435,15 @@ func Test_mutateDNSConfig(t *testing.T) {
 				p:          podMutateCtxFunc(v1.DNSDefault, nil, true),
 				vPod:       newPod(),
 				nameServer: "0.0.0.0",
+				dnsoptions: []v1.PodDNSConfigOption{
+					v1.PodDNSConfigOption{
+						Name: "use-vc",
+					},
+					v1.PodDNSConfigOption{
+						Name:  "ndots",
+						Value: pointer.StringPtr("5"),
+					},
+				},
 			},
 			expectedDNSPolicy: &dnsDefault,
 			expectedDNSConfig: nil,
@@ -405,6 +456,15 @@ func Test_mutateDNSConfig(t *testing.T) {
 					p.ObjectMeta.Labels[constants.TenantDisableDNSPolicyMutation] = "true"
 				}),
 				nameServer: "0.0.0.0",
+				dnsoptions: []v1.PodDNSConfigOption{
+					v1.PodDNSConfigOption{
+						Name: "use-vc",
+					},
+					v1.PodDNSConfigOption{
+						Name:  "ndots",
+						Value: pointer.StringPtr("5"),
+					},
+				},
 			},
 			expectedDNSPolicy: &dnsNone,
 			expectedDNSConfig: &v1.PodDNSConfig{
@@ -418,6 +478,15 @@ func Test_mutateDNSConfig(t *testing.T) {
 				p:          podMutateCtxFunc(v1.DNSClusterFirst, nil, false),
 				vPod:       newPod(),
 				nameServer: "0.0.0.0",
+				dnsoptions: []v1.PodDNSConfigOption{
+					v1.PodDNSConfigOption{
+						Name: "use-vc",
+					},
+					v1.PodDNSConfigOption{
+						Name:  "ndots",
+						Value: pointer.StringPtr("5"),
+					},
+				},
 			},
 			allowDNSPolicy:    true,
 			expectedDNSPolicy: &dnsNone,
@@ -430,6 +499,15 @@ func Test_mutateDNSConfig(t *testing.T) {
 					p.ObjectMeta.Labels[constants.TenantDisableDNSPolicyMutation] = "true"
 				}),
 				nameServer: "0.0.0.0",
+				dnsoptions: []v1.PodDNSConfigOption{
+					v1.PodDNSConfigOption{
+						Name: "use-vc",
+					},
+					v1.PodDNSConfigOption{
+						Name:  "ndots",
+						Value: pointer.StringPtr("5"),
+					},
+				},
 			},
 			allowDNSPolicy:    true,
 			expectedDNSPolicy: &dnsClusterFirst,
@@ -441,7 +519,7 @@ func Test_mutateDNSConfig(t *testing.T) {
 			if tt.allowDNSPolicy {
 				featuregate.DefaultFeatureGate.Set(featuregate.TenantAllowDNSPolicy, true)
 			}
-			mutateDNSConfig(tt.args.p, tt.args.vPod, tt.args.clusterDomain, tt.args.nameServer)
+			mutateDNSConfig(tt.args.p, tt.args.vPod, tt.args.clusterDomain, tt.args.nameServer, tt.args.dnsoptions)
 			if tt.expectedDNSPolicy != nil {
 				if tt.args.p.pPod.Spec.DNSPolicy != *tt.expectedDNSPolicy {
 					t.Errorf("expected DNSPolicy %+v, got %+v", *tt.expectedDNSPolicy, tt.args.p.pPod.Spec.DNSPolicy)

--- a/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -198,7 +198,7 @@ func (c *controller) reconcilePodCreate(clusterName, targetNamespace, requestUID
 
 	var ms = []conversion.PodMutator{
 		conversion.PodMutateServiceLink(c.Config.DisablePodServiceLinks),
-		conversion.PodMutateDefault(vPod, pSecretMap, services, nameServer),
+		conversion.PodMutateDefault(vPod, pSecretMap, services, nameServer, c.Config.DNSOptions),
 		conversion.PodMutateAutoMountServiceAccountToken(c.Config.DisableServiceAccountToken),
 		// TODO: make extension configurable
 		//conversion.PodAddExtensionMeta(vPod),


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
DnsOption needs to be entered by users according to their super cluster environment. Add flag to allow user to config DNSOptions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # N/A
