### PR TITLE
transfer k8s api to meet new version

### DIFF
--- a/virtualcluster/config/crd/tenancy.x-k8s.io_clusterversions.yaml
+++ b/virtualcluster/config/crd/tenancy.x-k8s.io_clusterversions.yaml
@@ -1,59 +1,30 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  labels:
-    controller-tools.k8s.io: "1.0"
   name: clusterversions.tenancy.x-k8s.io
 spec:
   group: tenancy.x-k8s.io
   names:
     kind: ClusterVersion
+    listKind: ClusterVersionList
     plural: clusterversions
+    shortNames:
+    - cv
+    singular: clusterversion
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            apiServer:
-              properties:
-                metadata:
-                  type: object
-                service:
-                  type: object
-                statefulset:
-                  type: object
-              type: object
-            controllerManager:
-              properties:
-                metadata:
-                  type: object
-                service:
-                  type: object
-                statefulset:
-                  type: object
-              type: object
-            etcd:
-              properties:
-                metadata:
-                  type: object
-                service:
-                  type: object
-                statefulset:
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-      type: object
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
The latest k8s version adopted by `Kind` is `v1.23`, and there are several API is deprecated and not support in the latest version, include:
- MutatingWebhookConfiguration and ValidatingWebhookConfiguration from `v1beta1` to `v1`
- apiextensions.k8s.io from `v1beta1` to `v1`

So update some code snippet to make it works with the new k8s version