### PR TITLE
Remove deprecated annotation for SVC, it block the installation of etcd

### DIFF
--- a/virtualcluster/config/sampleswithspec/clusterversion_v1_loadbalancer.yaml
+++ b/virtualcluster/config/sampleswithspec/clusterversion_v1_loadbalancer.yaml
@@ -99,9 +99,8 @@ spec:
     service:
       metadata:
         name: etcd
-        annotations:
-          service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
       spec:
+        publishNotReadyAddresses: true
         type: ClusterIP
         clusterIP: None
         selector:

--- a/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
+++ b/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
@@ -103,9 +103,8 @@ spec:
       kind: Service
       metadata:
         name: etcd
-        annotations:
-          service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
       spec:
+        publishNotReadyAddresses: true
         type: ClusterIP
         clusterIP: None
         selector:

--- a/virtualcluster/pkg/controller/controllers/clusterversion_controller_test.go
+++ b/virtualcluster/pkg/controller/controllers/clusterversion_controller_test.go
@@ -213,13 +213,11 @@ var defaultClusterVersion = &v1alpha1.ClusterVersionSpec{
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "etcd",
-				Annotations: map[string]string{
-					"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-				},
 			},
 			Spec: corev1.ServiceSpec{
-				Type:      corev1.ServiceTypeClusterIP,
-				ClusterIP: corev1.ClusterIPNone,
+				PublishNotReadyAddresses: true,
+				Type:                     corev1.ServiceTypeClusterIP,
+				ClusterIP:                corev1.ClusterIPNone,
 				Selector: map[string]string{
 					"component-name": "etcd",
 				},

--- a/virtualcluster/test/e2e/framework/clusterversion/create.go
+++ b/virtualcluster/test/e2e/framework/clusterversion/create.go
@@ -163,13 +163,11 @@ var defaultClusterVersion = &v1alpha1.ClusterVersionSpec{
 		Service: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "etcd",
-				Annotations: map[string]string{
-					"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-				},
 			},
 			Spec: corev1.ServiceSpec{
-				Type:      corev1.ServiceTypeClusterIP,
-				ClusterIP: corev1.ClusterIPNone,
+				PublishNotReadyAddresses: true,
+				Type:                     corev1.ServiceTypeClusterIP,
+				ClusterIP:                corev1.ClusterIPNone,
 				Selector: map[string]string{
 					"component-name": "etcd",
 				},


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
With the k8s version 1.22+, the `etcd` cannot install success, since the original annotation is deprecated:
`service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"`
That's make the `coredns` cannot resove the pod(etcd pod) which is not ready.

See the issue:
https://github.com/coredns/coredns/issues/5159#issuecomment-1033726643

