### PR TITLE
✨ Adding VN Agent PodIP Provider

### DIFF
--- a/virtualcluster/cmd/syncer/app/options/options.go
+++ b/virtualcluster/cmd/syncer/app/options/options.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,9 +19,10 @@ package options
 import (
 	"fmt"
 	"io/ioutil"
-	"k8s.io/utils/pointer"
 	"os"
 	"time"
+
+	"k8s.io/utils/pointer"
 
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
@@ -92,6 +93,7 @@ func NewResourceSyncerOptions() (*ResourceSyncerOptions, error) {
 			ExtraSyncingResources:      []string{},
 			VNAgentPort:                int32(10550),
 			VNAgentNamespacedName:      "vc-manager/vn-agent",
+			VNAgentLabelSelector:       "app=vn-agent",
 			FeatureGates: map[string]bool{
 				featuregate.SuperClusterPooling:        false,
 				featuregate.SuperClusterServiceNetwork: false,
@@ -128,6 +130,7 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs.Int32Var(&o.ComponentConfig.VNAgentPort, "vn-agent-port", 10550, "Port the vn-agent listens on")
 	fs.StringVar(&o.ComponentConfig.VNAgentNamespacedName, "vn-agent-namespace-name", "vc-manager/vn-agent", "Namespace/Name of the vn-agent running in cluster, used for VNodeProviderService")
 	fs.Var(cliflag.NewMapStringString(&o.DnsOptions), "dns-options", "DnsOptions is the default DNS options attached to each pod")
+	fs.StringVar(&o.ComponentConfig.VNAgentLabelSelector, "vn-agent-label-selector", "app=vn-agent", "Label key=value of the vn-agent running in cluster, used for VNodeProviderPodIP")
 
 	serverFlags := fss.FlagSet("metricsServer")
 	serverFlags.StringVar(&o.Address, "address", o.Address, "The server address.")

--- a/virtualcluster/pkg/syncer/apis/config/types.go
+++ b/virtualcluster/pkg/syncer/apis/config/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -65,6 +65,10 @@ type SyncerConfiguration struct {
 	// VNAgentNamespacedName defines the namespace/name of the VN Agent Kubernetes
 	// service, this is used for feature VNodeProviderService.
 	VNAgentNamespacedName string
+
+	// VNAgentLabelSelector defines the label of the VN Agent Kubernetes pods, this
+	// is used for the feature VNodeProviderPodIP
+	VNAgentLabelSelector string
 
 	// FeatureGates enabled by the user.
 	FeatureGates map[string]bool

--- a/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ const (
 	// tenant pods to label themselves and use dnsPolicy's like `ClusterFirst`
 	// from the super cluster
 	TenantAllowDNSPolicy = "TenantAllowDNSPolicy"
+
+	// VNodeProviderPodIP is an experimental feature that allows the
+	// vn-agent to run as a daemonset but run without hostNetworking and
+	// accessed by the PodIP on each pod on the node
+	VNodeProviderPodIP = "VNodeProviderPodIP"
 )
 
 var defaultFeatures = FeatureList{
@@ -57,6 +62,7 @@ var defaultFeatures = FeatureList{
 	SuperClusterServiceNetwork: {Default: false},
 	VNodeProviderService:       {Default: false},
 	TenantAllowDNSPolicy:       {Default: false},
+	VNodeProviderPodIP:         {Default: false},
 }
 
 type Feature string

--- a/virtualcluster/pkg/syncer/vnode/pod/provider_test.go
+++ b/virtualcluster/pkg/syncer/vnode/pod/provider_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func newNode(name string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: v1.NodeStatus{
+			Addresses: []v1.NodeAddress{
+				v1.NodeAddress{
+					Type:    v1.NodeInternalIP,
+					Address: "192.168.0.2",
+				},
+			},
+		},
+	}
+}
+
+func newClient() clientset.Interface {
+	return fake.NewSimpleClientset(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vn-agent-12345",
+			Namespace: "vc-manager",
+			Labels: map[string]string{
+				"app": "vn-agent",
+			},
+		},
+		Spec: v1.PodSpec{
+			NodeName: "node1",
+		},
+		Status: v1.PodStatus{
+			PodIP: "192.168.0.5",
+		},
+	})
+}
+
+func Test_provider_GetNodeAddress(t *testing.T) {
+	type fields struct {
+		vnAgentPort          int32
+		vnAgentNamespaceName string
+		vnAgentLabelSelector string
+		client               clientset.Interface
+	}
+	type args struct {
+		node *v1.Node
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []v1.NodeAddress
+		wantErr bool
+	}{
+		{
+			name: "TestWithNoPods",
+			fields: fields{
+				vnAgentNamespaceName: "default/vn-agent",
+				vnAgentLabelSelector: "no=pods",
+				client:               newClient(),
+			},
+			args:    args{newNode("node1")},
+			want:    []v1.NodeAddress{},
+			wantErr: true,
+		},
+		{
+			name: "TestWithPodsButWrongNodeName",
+			fields: fields{
+				vnAgentNamespaceName: "vc-manager/vn-agent",
+				vnAgentLabelSelector: "app=vn-agent",
+				client:               newClient(),
+			},
+			args:    args{newNode("node2")},
+			want:    []v1.NodeAddress{},
+			wantErr: true,
+		},
+		{
+			name: "TestWithPods",
+			fields: fields{
+				vnAgentNamespaceName: "vc-manager/vn-agent",
+				vnAgentLabelSelector: "app=vn-agent",
+				client:               newClient(),
+			},
+			args: args{newNode("node1")},
+			want: []v1.NodeAddress{
+				v1.NodeAddress{
+					Type:    v1.NodeInternalIP,
+					Address: "192.168.0.5",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &provider{
+				vnAgentPort:          tt.fields.vnAgentPort,
+				vnAgentNamespaceName: tt.fields.vnAgentNamespaceName,
+				vnAgentLabelSelector: tt.fields.vnAgentLabelSelector,
+				client:               tt.fields.client,
+			}
+			got, err := p.GetNodeAddress(tt.args.node)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("provider.GetNodeAddress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(tt.want) != 0 && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("provider.GetNodeAddress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/virtualcluster/pkg/syncer/vnode/vnode.go
+++ b/virtualcluster/pkg/syncer/vnode/vnode.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/util/featuregate"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/vnode/native"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/vnode/pod"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/vnode/provider"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/vnode/service"
 	utilconstants "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/constants"
@@ -42,6 +43,9 @@ import (
 func GetNodeProvider(config *config.SyncerConfiguration, client clientset.Interface) provider.VirtualNodeProvider {
 	if featuregate.DefaultFeatureGate.Enabled(featuregate.VNodeProviderService) {
 		return service.NewServiceVirtualNodeProvider(config.VNAgentPort, config.VNAgentNamespacedName, client)
+	}
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.VNodeProviderPodIP) {
+		return pod.NewPodVirtualNodeProvider(config.VNAgentPort, config.VNAgentNamespacedName, config.VNAgentLabelSelector, client)
 	}
 	return native.NewNativeVirtualNodeProvider(config.VNAgentPort)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the ability to use the `vn-agent` as a `DaemonSet` but uses vn-agent pod IPs as the routable address to configure with the vnode UWS'ed object. Because this interface is used for all syncing any updates to the node status object trigger a reconciliation. We handle vn-agent pod failures with status updates which triggers a resync.

> ⚠️  For anyone implementing this you should have a node level check for example `node-exporter` or an `initContainer` on the vn-agent which updates a condition on the Node or other part of the node object. By doing this the syncer will update all your VirtualClusters VNodes anytime the `vn-agent` is rescheduled, this can be done without rebinding.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

No issue filed. 

Signed-off-by: Chris Hein <me@chrishein.com>