### PR TITLE
✨ Add SuperClusterLabelling experimental feature gate

### DIFF
--- a/controlplane/nested/certificate/helpers.go
+++ b/controlplane/nested/certificate/helpers.go
@@ -76,7 +76,7 @@ func NewAPIServerCrtAndKey(ca *KeyPair, clusterName, clusterDomainArg, apiserver
 // NewAPIServerKubeletClientCertAndKey creates certificate for the apiservers to connect to the
 // kubelets securely, signed by the ca.
 // A hack to use namespace as CN because vn-agent is using this CN to figure out the namespace in
-// super cluster for kubectl exec/log/port forward
+// super cluster for kubectl exec/log/port forward.
 func NewAPIServerKubeletClientCertAndKey(ca *KeyPair, namespace string) (*KeyPair, error) {
 	config := &util.CertConfig{
 		Config: cert.Config{

--- a/virtualcluster/pkg/syncer/constants/constants.go
+++ b/virtualcluster/pkg/syncer/constants/constants.go
@@ -23,6 +23,8 @@ import (
 )
 
 const (
+	// LabelControlled records the object is controlled by virtualcluster controllers.
+	LabelControlled = "tenancy.x-k8s.io/controlled"
 	// LabelCluster records which cluster this resource belongs to.
 	LabelCluster = "tenancy.x-k8s.io/cluster"
 	// LabelUID is the uid in the tenant namespace.

--- a/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/virtualcluster/pkg/syncer/conversion/helper.go
@@ -208,6 +208,17 @@ func (c *objectConversion) BuildSuperClusterNamespace(cluster string, obj client
 		return nil, errors.Wrapf(err, "get cluster owner info")
 	}
 
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.SuperClusterLabelling) {
+		labels := m.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+
+		labels[constants.LabelControlled] = "true"
+
+		m.SetLabels(labels)
+	}
+
 	anno := m.GetAnnotations()
 	if anno == nil {
 		anno = make(map[string]string)

--- a/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -41,6 +41,10 @@ const (
 	// pool multiple super clusters for use with the experimental scheduler
 	SuperClusterPooling = "SuperClusterPooling"
 
+	// SuperClusterLabelling is an experimental feature that allows the syncer to
+	// label managed resources in super cluster for easier filtering.
+	SuperClusterLabelling = "SuperClusterLabelling"
+
 	// VNodeProviderService is an experimental feature that allows the
 	// vn-agent to run as a load balanced deployment proxy to the super
 	// cluster API Server
@@ -60,6 +64,7 @@ const (
 var defaultFeatures = FeatureList{
 	SuperClusterPooling:        {Default: false},
 	SuperClusterServiceNetwork: {Default: false},
+	SuperClusterLabelling:      {Default: false},
 	VNodeProviderService:       {Default: false},
 	TenantAllowDNSPolicy:       {Default: false},
 	VNodeProviderPodIP:         {Default: false},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new feature gate `SuperClusterLabelling` which enables adding labels to the namespaces created by syncer.
This behaviour could be extended for any other resources, but starts from namespaces as the particular case. 

**Which issue(s) this PR fixes**:
fixes #272, requires a follow-up with enabling labels for filtering too: https://github.com/kubernetes-sigs/cluster-api-provider-nested/blob/1e987ad6c3c6ef0099e898b1b6589975212523b9/virtualcluster/pkg/syncer/resources/namespace/checker.go#L90

The changes are intentionally split by different PRs to allow operator to ensure all namespace are already labelled before reducing the scope of syncer/resources/namespace/checker: garbage collector
