### PR TITLE
✨ Add SuperClusterLabelFilter experimental feature gate

### DIFF
--- a/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/virtualcluster/pkg/syncer/conversion/helper.go
@@ -197,6 +197,15 @@ func (c *objectConversion) CleanOpaqueKeys(vc *v1alpha1.VirtualCluster, keyMap m
 	}
 }
 
+func WithSuperClusterLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	labels[constants.LabelControlled] = "true"
+	return labels
+}
+
 func (c *objectConversion) BuildSuperClusterNamespace(cluster string, obj client.Object) (client.Object, error) {
 	m, err := c.buildCleanSuperClusterObject(cluster, obj)
 	if err != nil {
@@ -209,14 +218,7 @@ func (c *objectConversion) BuildSuperClusterNamespace(cluster string, obj client
 	}
 
 	if featuregate.DefaultFeatureGate.Enabled(featuregate.SuperClusterLabelling) {
-		labels := m.GetLabels()
-		if labels == nil {
-			labels = make(map[string]string)
-		}
-
-		labels[constants.LabelControlled] = "true"
-
-		m.SetLabels(labels)
+		m.SetLabels(WithSuperClusterLabels(m.GetLabels()))
 	}
 
 	anno := m.GetAnnotations()

--- a/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -45,6 +45,11 @@ const (
 	// label managed resources in super cluster for easier filtering.
 	SuperClusterLabelling = "SuperClusterLabelling"
 
+	// SuperClusterLabelFilter is an experimental feature that allows the syncer to
+	// use labels to filter managed resources in super cluster.
+	// The feature requires SuperClusterLabelling=true.
+	SuperClusterLabelFilter = "SuperClusterLabelFilter"
+
 	// VNodeProviderService is an experimental feature that allows the
 	// vn-agent to run as a load balanced deployment proxy to the super
 	// cluster API Server
@@ -65,6 +70,7 @@ var defaultFeatures = FeatureList{
 	SuperClusterPooling:        {Default: false},
 	SuperClusterServiceNetwork: {Default: false},
 	SuperClusterLabelling:      {Default: false},
+	SuperClusterLabelFilter:    {Default: false},
 	VNodeProviderService:       {Default: false},
 	TenantAllowDNSPolicy:       {Default: false},
 	VNodeProviderPodIP:         {Default: false},


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR is a follow-up feature gate to SuperClusterLabelling https://github.com/kubernetes-sigs/cluster-api-provider-nested/pull/273.
It adds new feature gate SuperClusterLabelFilter with namespace checker implementation to allow use label filter requesting super cluster namespaces, instead of doing the full list. It should reduce load to super cluster control plane in multi-platform super clusters (i.e. when super cluster itself is multi-tenant in addition to virtual clusters).