### PR TITLE
✨ Use SuperClusterLabelFilter feature gate for all objects if enabled

### DIFF
--- a/virtualcluster/pkg/syncer/resources/configmap/checker.go
+++ b/virtualcluster/pkg/syncer/resources/configmap/checker.go
@@ -22,7 +22,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -56,7 +55,7 @@ func (c *controller) PatrollerDo() {
 		return
 	}
 
-	pConfigMaps, err := c.configMapLister.List(labels.Everything())
+	pConfigMaps, err := c.configMapLister.List(util.GetSuperClusterListerLabelsSelector())
 	if err != nil {
 		klog.Errorf("error listing configmaps from super master informer cache: %v", err)
 		return

--- a/virtualcluster/pkg/syncer/resources/endpoints/checker.go
+++ b/virtualcluster/pkg/syncer/resources/endpoints/checker.go
@@ -20,7 +20,6 @@ import (
 	"sync/atomic"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -29,6 +28,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/conversion"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/metrics"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/patrol/differ"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/util"
 )
 
 var numMissingEndPoints uint64
@@ -57,7 +57,7 @@ func (c *controller) PatrollerDo() {
 	numMissingEndPoints = 0
 	numMissMatchedEndPoints = 0
 
-	pList, err := c.endpointsLister.List(labels.Everything())
+	pList, err := c.endpointsLister.List(util.GetSuperClusterListerLabelsSelector())
 	if err != nil {
 		klog.Errorf("error listing endpoints from super master informer cache: %v", err)
 		return

--- a/virtualcluster/pkg/syncer/resources/ingress/checker.go
+++ b/virtualcluster/pkg/syncer/resources/ingress/checker.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -71,9 +70,9 @@ func (c *controller) PatrollerDo() {
 	}
 	wg.Wait()
 
-	pIngresses, err := c.ingressLister.List(labels.Everything())
+	pIngresses, err := c.ingressLister.List(util.GetSuperClusterListerLabelsSelector())
 	if err != nil {
-		klog.Errorf("error listing ingresss from super master informer cache: %v", err)
+		klog.Errorf("error listing ingresses from super master informer cache: %v", err)
 		return
 	}
 

--- a/virtualcluster/pkg/syncer/resources/namespace/checker.go
+++ b/virtualcluster/pkg/syncer/resources/namespace/checker.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -87,16 +86,7 @@ func (c *controller) PatrollerDo() {
 		klog.V(4).Infof("super cluster has no tenant control planes, still check %s for gc purpose", "namespace")
 	}
 
-	var nsFilter labels.Selector
-	// Use SuperClusterLabelFilter feature gate only if SuperClusterLabelling enabled,
-	// otherwise filter will do return nothing.
-	if featuregate.DefaultFeatureGate.Enabled(featuregate.SuperClusterLabelFilter) && featuregate.DefaultFeatureGate.Enabled(featuregate.SuperClusterLabelling) {
-		nsFilter = labels.Set{constants.LabelControlled: "true"}.AsSelector()
-	} else {
-		nsFilter = labels.Everything()
-	}
-
-	pList, err := c.nsLister.List(nsFilter)
+	pList, err := c.nsLister.List(util.GetSuperClusterListerLabelsSelector())
 	if err != nil {
 		klog.Errorf("error listing namespaces from super master informer cache: %v", err)
 		return

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/checker.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/checker.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -56,7 +55,7 @@ func (c *controller) PatrollerDo() {
 
 	numMissMatchedPVCs = 0
 
-	pList, err := c.pvcLister.List(labels.Everything())
+	pList, err := c.pvcLister.List(util.GetSuperClusterListerLabelsSelector())
 	if err != nil {
 		klog.Errorf("error listing pvc from super master informer cache: %v", err)
 		return

--- a/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -25,7 +25,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -144,7 +143,7 @@ func (c *controller) PatrollerDo() {
 	numSpecMissMatchedPods = 0
 	numUWMetaMissMatchedPods = 0
 
-	pList, err := c.podLister.List(labels.Everything())
+	pList, err := c.podLister.List(util.GetSuperClusterListerLabelsSelector())
 	if err != nil {
 		klog.Errorf("error listing pod from super master informer cache: %v", err)
 		return

--- a/virtualcluster/pkg/syncer/resources/secret/checker.go
+++ b/virtualcluster/pkg/syncer/resources/secret/checker.go
@@ -67,7 +67,7 @@ func (c *controller) PatrollerDo() {
 	}
 	wg.Wait()
 
-	secretList, err := c.secretLister.List(labels.Everything())
+	secretList, err := c.secretLister.List(util.GetSuperClusterListerLabelsSelector())
 	if err != nil {
 		klog.Errorf("error listing secret from super master informer cache: %v", err)
 		return

--- a/virtualcluster/pkg/syncer/resources/service/checker.go
+++ b/virtualcluster/pkg/syncer/resources/service/checker.go
@@ -24,7 +24,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -61,7 +60,7 @@ func (c *controller) PatrollerDo() {
 	numStatusMissMatchedServices = 0
 	numUWMetaMissMatchedServices = 0
 
-	pList, err := c.serviceLister.List(labels.Everything())
+	pList, err := c.serviceLister.List(util.GetSuperClusterListerLabelsSelector())
 	if err != nil {
 		klog.Errorf("error listing service from super master informer cache: %v", err)
 		return

--- a/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
+++ b/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
@@ -21,7 +21,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/metrics"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/patrol/differ"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/util"
 )
 
 func (c *controller) StartPatrol(stopCh <-chan struct{}) error {
@@ -51,9 +51,9 @@ func (c *controller) PatrollerDo() {
 		return
 	}
 
-	pList, err := c.saLister.List(labels.Everything())
+	pList, err := c.saLister.List(util.GetSuperClusterListerLabelsSelector())
 	if err != nil {
-		klog.Errorf("error listing pvc from super master informer cache: %v", err)
+		klog.Errorf("error listing service accounts from super master informer cache: %v", err)
 		return
 	}
 	pSet := differ.NewDiffSet()
@@ -66,7 +66,7 @@ func (c *controller) PatrollerDo() {
 	for _, cluster := range clusterNames {
 		vList := &v1.ServiceAccountList{}
 		if err := c.MultiClusterController.List(cluster, vList); err != nil {
-			klog.Errorf("error listing serviceaccount from cluster %s informer cache: %v", cluster, err)
+			klog.Errorf("error listing service accounts from cluster %s informer cache: %v", cluster, err)
 			knownClusterSet.Delete(cluster)
 			continue
 		}

--- a/virtualcluster/pkg/syncer/util/helper.go
+++ b/virtualcluster/pkg/syncer/util/helper.go
@@ -19,7 +19,11 @@ package util
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/labels"
+
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/util/featuregate"
 	mc "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/mccontroller"
 )
 
@@ -35,4 +39,14 @@ func GetVirtualClusterObject(mc mc.MultiClusterInterface, clustername string) (*
 	}
 
 	return vc, nil
+}
+
+// GetSuperClusterListerLabelsSelector returns labels.Selector for super cluster objects using feature gate.
+func GetSuperClusterListerLabelsSelector() labels.Selector {
+	// Use SuperClusterLabelFilter feature gate only if SuperClusterLabelling enabled,
+	// otherwise filter will do return nothing.
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.SuperClusterLabelFilter) && featuregate.DefaultFeatureGate.Enabled(featuregate.SuperClusterLabelling) {
+		return labels.Set{constants.LabelControlled: "true"}.AsSelector()
+	}
+	return labels.Everything()
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
#279 introduced labelling for all objects, so this PR adds filtering to all checkers where it is possible.

There are couple checkers (priority class, storage class, persistent volume) that are used for back populating only and have nothing to do with virtual clusters initially, so they still have labels.Everything() selector. All other checkers are used for synchronisation and garbage collecting, so labelling should help to reduce control-plane operations and overall controller memory consumption in clusters, where super-cluster is used outside of nested scope.

