### PR TITLE
✨ Add external apiserver domain to the APIServer certificate

### DIFF
--- a/virtualcluster/pkg/controller/pki/pki.go
+++ b/virtualcluster/pkg/controller/pki/pki.go
@@ -26,7 +26,9 @@ import (
 	"net"
 
 	"k8s.io/client-go/util/cert"
+
 	tenancyv1alpha1 "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/conversion"
 	pkiutil "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/pki"
 )
@@ -68,6 +70,10 @@ func NewAPIServerCrtAndKey(ca *CrtKeyPair, vc *tenancyv1alpha1.VirtualCluster, a
 			// add virtual cluster name (i.e. namespace) for vn-agent
 			vc.Name,
 		},
+	}
+
+	if externalApiserverDomain, ok := vc.Labels[constants.LabelExternalApiserverDomain]; ok {
+		altNames.DNSNames = append(altNames.DNSNames, externalApiserverDomain)
 	}
 
 	for _, ip := range apiserverIPs {

--- a/virtualcluster/pkg/syncer/constants/constants.go
+++ b/virtualcluster/pkg/syncer/constants/constants.go
@@ -50,6 +50,9 @@ const (
 	// LabelVCRootNS means the namespace is the rootns created by vc-manager.
 	LabelVCRootNS = "tenancy.x-k8s.io/vcrootns"
 
+	// LabelExternalApiserverDomain is the domain name for apiserver url from outside the cluster
+	LabelExternalApiserverDomain = "tenancy.x-k8s.io/external-apiserver-domain"
+
 	// LabelSecretUID is the service account token secret UID in tenant namespace.
 	LabelSecretUID = "tenancy.x-k8s.io/secret.UID"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR checks the presence of `tenancy.x-k8s.io/external-apiserver-domain` label in VirtualCluster object and adds it contents to the list of altNames.DNSNames in the apiserver certificate, allowing access to the apiserver from outside of the cluster (through an external LoadBalancer service).
This is the responsibility of an operator or other controllers to set that label according to the super-cluster configuration.
