### PR TITLE
✨ Control Plane Upgrades

### DIFF
--- a/virtualcluster/pkg/controller/controllers/clusterversion_controller_test.go
+++ b/virtualcluster/pkg/controller/controllers/clusterversion_controller_test.go
@@ -95,7 +95,7 @@ var defaultClusterVersion = &v1alpha1.ClusterVersionSpec{
 					},
 				},
 				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
-					Type: appsv1.OnDeleteStatefulSetStrategyType,
+					Type: appsv1.RollingUpdateStatefulSetStrategyType,
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
@@ -247,7 +247,7 @@ var defaultClusterVersion = &v1alpha1.ClusterVersionSpec{
 					},
 				},
 				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
-					Type: appsv1.OnDeleteStatefulSetStrategyType,
+					Type: appsv1.RollingUpdateStatefulSetStrategyType,
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
@@ -302,6 +302,7 @@ var defaultClusterVersion = &v1alpha1.ClusterVersionSpec{
 									{
 										ContainerPort: 6443,
 										Name:          "api",
+										Protocol:      corev1.ProtocolTCP, // Must be explicit in 1.19
 									},
 								},
 								LivenessProbe: &corev1.Probe{
@@ -453,7 +454,7 @@ var defaultClusterVersion = &v1alpha1.ClusterVersionSpec{
 					},
 				},
 				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
-					Type: appsv1.OnDeleteStatefulSetStrategyType,
+					Type: appsv1.RollingUpdateStatefulSetStrategyType,
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/virtualcluster/pkg/controller/controllers/metrics.go
+++ b/virtualcluster/pkg/controller/controllers/metrics.go
@@ -2,9 +2,6 @@ package controllers
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
-
-	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/util/featuregate"
 )
 
 var (
@@ -23,10 +20,3 @@ var (
 		[]string{"cluster_version", "resource_version"},
 	)
 )
-
-func init() {
-	// Expose featuregate.ClusterVersionApplyCurrentState metrics only if it enabled
-	if featuregate.DefaultFeatureGate.Enabled(featuregate.ClusterVersionApplyCurrentState) {
-		metrics.Registry.MustRegister(clustersUpdatedCounter, clustersUpdateSeconds)
-	}
-}

--- a/virtualcluster/pkg/controller/controllers/metrics.go
+++ b/virtualcluster/pkg/controller/controllers/metrics.go
@@ -14,8 +14,9 @@ var (
 	)
 	clustersUpdateSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "clusters_update_seconds",
-			Help: "Duration of cluster upgrade by reconciler in featuregate.ClusterVersionApplyCurrentState",
+			Name:    "clusters_update_seconds",
+			Help:    "Duration of cluster upgrade by reconciler in featuregate.ClusterVersionApplyCurrentState",
+			Buckets: []float64{.1, .5, 1, 5, 10, 20, 30, 60, 90, 120, 300, 600, 900},
 		},
 		[]string{"cluster_version", "resource_version"},
 	)

--- a/virtualcluster/pkg/controller/controllers/metrics.go
+++ b/virtualcluster/pkg/controller/controllers/metrics.go
@@ -5,17 +5,24 @@ import (
 )
 
 var (
-	clustersUpdatedCounter = prometheus.NewCounterVec(
+	clustersUpgradedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "clusters_updated",
-			Help: "Amount of clusters upgraded by reconciler in featuregate.ClusterVersionApplyCurrentState",
+			Name: "clusters_upgraded",
+			Help: "Amount of clusters upgraded by reconciler in featuregate.ClusterVersionPartialUpgrade",
 		},
 		[]string{"cluster_version", "resource_version"},
 	)
-	clustersUpdateSeconds = prometheus.NewHistogramVec(
+	clustersUpgradeFailedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "clusters_upgrade_failed",
+			Help: "Amount of clusters failed to upgrade by reconciler in featuregate.ClusterVersionPartialUpgrade",
+		},
+		[]string{"cluster_version", "resource_version"},
+	)
+	clustersUpgradeSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "clusters_update_seconds",
-			Help:    "Duration of cluster upgrade by reconciler in featuregate.ClusterVersionApplyCurrentState",
+			Name:    "clusters_upgrade_seconds",
+			Help:    "Duration of cluster upgrade by reconciler in featuregate.ClusterVersionPartialUpgrade",
 			Buckets: []float64{.1, .5, 1, 5, 10, 20, 30, 60, 90, 120, 300, 600, 900},
 		},
 		[]string{"cluster_version", "resource_version"},

--- a/virtualcluster/pkg/controller/controllers/metrics.go
+++ b/virtualcluster/pkg/controller/controllers/metrics.go
@@ -1,0 +1,32 @@
+package controllers
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/util/featuregate"
+)
+
+var (
+	clustersUpdatedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "clusters_updated",
+			Help: "Amount of clusters upgraded by reconciler in featuregate.ClusterVersionApplyCurrentState",
+		},
+		[]string{"cluster_version", "resource_version"},
+	)
+	clustersUpdateSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "clusters_update_seconds",
+			Help: "Duration of cluster upgrade by reconciler in featuregate.ClusterVersionApplyCurrentState",
+		},
+		[]string{"cluster_version", "resource_version"},
+	)
+)
+
+func init() {
+	// Expose featuregate.ClusterVersionApplyCurrentState metrics only if it enabled
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.ClusterVersionApplyCurrentState) {
+		metrics.Registry.MustRegister(clustersUpdatedCounter, clustersUpdateSeconds)
+	}
+}

--- a/virtualcluster/pkg/controller/controllers/provisioner/provisioner.go
+++ b/virtualcluster/pkg/controller/controllers/provisioner/provisioner.go
@@ -26,4 +26,6 @@ type Provisioner interface {
 	CreateVirtualCluster(ctx context.Context, vc *tenancyv1alpha1.VirtualCluster) error
 	DeleteVirtualCluster(ctx context.Context, vc *tenancyv1alpha1.VirtualCluster) error
 	GetProvisioner() string
+	// UpgradeVirtualCluster is used to apply current clusterversion if featuregate.VirtualClusterApplyUpdate enabled
+	UpgradeVirtualCluster(ctx context.Context, vc *tenancyv1alpha1.VirtualCluster) error
 }

--- a/virtualcluster/pkg/controller/controllers/provisioner/provisioner_aliyun.go
+++ b/virtualcluster/pkg/controller/controllers/provisioner/provisioner_aliyun.go
@@ -288,3 +288,7 @@ OuterLoop:
 func (mpa *Aliyun) GetProvisioner() string {
 	return "aliyun"
 }
+
+func (mpa *Aliyun) UpgradeVirtualCluster(ctx context.Context, vc *tenancyv1alpha1.VirtualCluster) error {
+	return fmt.Errorf("not implemented")
+}

--- a/virtualcluster/pkg/controller/controllers/provisioner/provisioner_native.go
+++ b/virtualcluster/pkg/controller/controllers/provisioner/provisioner_native.go
@@ -68,7 +68,7 @@ func NewProvisionerNative(mgr manager.Manager, log logr.Logger, provisionerTimeo
 }
 
 func updateLabelClusterVersionApplied(vc *tenancyv1alpha1.VirtualCluster, cv *tenancyv1alpha1.ClusterVersion) {
-	if featuregate.DefaultFeatureGate.Enabled(featuregate.VirtualClusterApplyUpdate) {
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.ClusterVersionApplyCurrentState) {
 		if vc.Labels == nil {
 			vc.Labels = map[string]string{}
 		}

--- a/virtualcluster/pkg/controller/controllers/suite_test.go
+++ b/virtualcluster/pkg/controller/controllers/suite_test.go
@@ -73,7 +73,7 @@ var _ = BeforeSuite(func() {
 	err = apis.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	Expect(featuregate.DefaultFeatureGate.Set(featuregate.VirtualClusterApplyUpdate, true)).NotTo(HaveOccurred())
+	Expect(featuregate.DefaultFeatureGate.Set(featuregate.ClusterVersionApplyCurrentState, true)).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 

--- a/virtualcluster/pkg/controller/controllers/suite_test.go
+++ b/virtualcluster/pkg/controller/controllers/suite_test.go
@@ -73,7 +73,7 @@ var _ = BeforeSuite(func() {
 	err = apis.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	Expect(featuregate.DefaultFeatureGate.Set(featuregate.ClusterVersionApplyCurrentState, true)).NotTo(HaveOccurred())
+	Expect(featuregate.DefaultFeatureGate.Set(featuregate.ClusterVersionPartialUpgrade, true)).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 

--- a/virtualcluster/pkg/controller/controllers/suite_test.go
+++ b/virtualcluster/pkg/controller/controllers/suite_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/apis"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/util/featuregate"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -71,6 +72,8 @@ var _ = BeforeSuite(func() {
 
 	err = apis.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
+
+	Expect(featuregate.DefaultFeatureGate.Set(featuregate.VirtualClusterApplyUpdate, true)).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 

--- a/virtualcluster/pkg/controller/controllers/virtualcluster_controller.go
+++ b/virtualcluster/pkg/controller/controllers/virtualcluster_controller.go
@@ -71,8 +71,8 @@ func (r *ReconcileVirtualCluster) SetupWithManager(mgr ctrl.Manager, opts contro
 	}
 	r.Provisioner = provisioner
 
-	// Expose featuregate.ClusterVersionApplyCurrentState metrics only if it enabled
-	if featuregate.DefaultFeatureGate.Enabled(featuregate.ClusterVersionApplyCurrentState) {
+	// Expose featuregate.ClusterVersionPartialUpgrade metrics only if it enabled
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.ClusterVersionPartialUpgrade) {
 		metrics.Registry.MustRegister(
 			clustersUpdatedCounter,
 			clustersUpdateSeconds,
@@ -175,7 +175,7 @@ func (r *ReconcileVirtualCluster) Reconcile(ctx context.Context, request reconci
 		return
 	case tenancyv1alpha1.ClusterRunning:
 		r.Log.Info("VirtualCluster is running", "vc", vc.GetName())
-		if !featuregate.DefaultFeatureGate.Enabled(featuregate.ClusterVersionApplyCurrentState) {
+		if !featuregate.DefaultFeatureGate.Enabled(featuregate.ClusterVersionPartialUpgrade) {
 			return
 		}
 		if isReady, ok := vc.Labels[constants.LabelVCReadyForUpgrade]; !ok || isReady != "true" {

--- a/virtualcluster/pkg/controller/controllers/virtualcluster_controller.go
+++ b/virtualcluster/pkg/controller/controllers/virtualcluster_controller.go
@@ -27,10 +27,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	tenancyv1alpha1 "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/apis/tenancy/v1alpha1"
@@ -70,6 +70,14 @@ func (r *ReconcileVirtualCluster) SetupWithManager(mgr ctrl.Manager, opts contro
 		return err
 	}
 	r.Provisioner = provisioner
+
+	// Expose featuregate.ClusterVersionApplyCurrentState metrics only if it enabled
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.ClusterVersionApplyCurrentState) {
+		metrics.Registry.MustRegister(
+			clustersUpdatedCounter,
+			clustersUpdateSeconds,
+		)
+	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(opts).

--- a/virtualcluster/pkg/controller/controllers/virtualcluster_controller.go
+++ b/virtualcluster/pkg/controller/controllers/virtualcluster_controller.go
@@ -167,7 +167,7 @@ func (r *ReconcileVirtualCluster) Reconcile(ctx context.Context, request reconci
 		return
 	case tenancyv1alpha1.ClusterRunning:
 		r.Log.Info("VirtualCluster is running", "vc", vc.GetName())
-		if !featuregate.DefaultFeatureGate.Enabled(featuregate.VirtualClusterApplyUpdate) {
+		if !featuregate.DefaultFeatureGate.Enabled(featuregate.ClusterVersionApplyCurrentState) {
 			return
 		}
 		if isReady, ok := vc.Labels[constants.LabelVCReadyForUpgrade]; !ok || isReady != "true" {

--- a/virtualcluster/pkg/controller/controllers/virtualcluster_controller_test.go
+++ b/virtualcluster/pkg/controller/controllers/virtualcluster_controller_test.go
@@ -18,10 +18,10 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +32,7 @@ import (
 
 	tenancyv1alpha1 "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/apis/tenancy/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/controller/secret"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants"
 )
 
 func getClusterObjectKey(instance *tenancyv1alpha1.VirtualCluster, name string) client.ObjectKey {
@@ -41,11 +42,14 @@ func getClusterObjectKey(instance *tenancyv1alpha1.VirtualCluster, name string) 
 var _ = Describe("VirtualCluster Controller", func() {
 
 	Context("Reconcile VirtualCluster Cluster", func() {
+		var cvInstance *tenancyv1alpha1.ClusterVersion
+		var instance *tenancyv1alpha1.VirtualCluster
+
 		It("Should create resources successfully", func() {
 			ctx := context.TODO()
 			Expect(cli).ShouldNot(BeNil())
 
-			cvInstance := createClusterVersion()
+			cvInstance = createClusterVersion()
 			Expect(cli.Create(ctx, cvInstance)).Should(Succeed())
 
 			By("Fetching ClusterVersion")
@@ -55,7 +59,7 @@ var _ = Describe("VirtualCluster Controller", func() {
 				return !apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 
-			instance := &tenancyv1alpha1.VirtualCluster{
+			instance = &tenancyv1alpha1.VirtualCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "virtualcluster-sample",
 					Namespace:    "default",
@@ -161,9 +165,71 @@ var _ = Describe("VirtualCluster Controller", func() {
 			By("Faking controller-manager STS Status Updates")
 			err = cli.Status().Update(ctx, cmSts)
 			Expect(err).To(BeNil())
+		})
+		It("Should upgrade resources successfully", func() {
+			ctx := context.TODO()
+			Expect(cli).ShouldNot(BeNil())
 
+			objectKey := client.ObjectKeyFromObject(instance)
+
+			By("Checking cluster phase")
+			Eventually(func() bool {
+				err := cli.Get(ctx, objectKey, instance)
+				return err == nil && instance.Status.Phase == tenancyv1alpha1.ClusterRunning
+			}, time.Minute*5, interval).Should(BeTrue())
+
+			By("Updating ClusterVersion")
+			cvInstance.Spec.ETCD.StatefulSet.Spec.Template.Spec.Containers[0].Args = append([]string{"-debug"}, cvInstance.Spec.ETCD.StatefulSet.Spec.Template.Spec.Containers[0].Args...)
+			cvInstance.Spec.APIServer.StatefulSet.Spec.Template.Spec.Containers[0].Args = append([]string{"-v=7"}, cvInstance.Spec.APIServer.StatefulSet.Spec.Template.Spec.Containers[0].Args...)
+			if cvInstance.Spec.APIServer.Service.Labels == nil {
+				cvInstance.Spec.APIServer.Service.Labels = map[string]string{}
+			}
+			cvInstance.Spec.APIServer.Service.Labels["test-label"] = "test"
+			cvInstance.Spec.ControllerManager.StatefulSet.Spec.Template.Spec.Containers[0].Args = append([]string{"-v=7"}, cvInstance.Spec.ControllerManager.StatefulSet.Spec.Template.Spec.Containers[0].Args...)
+			cvInstance.ObjectMeta.ManagedFields = nil
+			forceTrue := true
+			Expect(cli.Patch(ctx, cvInstance, client.Apply, &client.PatchOptions{Force: &forceTrue, FieldManager: "test"})).Should(Succeed())
+
+			By("Enable upgrade for cluster")
+			instance.Labels[constants.LabelVCReadyForUpgrade] = "true"
+			instance.ObjectMeta.ManagedFields = nil
+			Expect(cli.Patch(ctx, instance, client.Apply, &client.PatchOptions{Force: &forceTrue, FieldManager: "test"})).Should(Succeed())
+
+			By("APIServer Service upgraded")
+			Eventually(func() bool {
+				svcObjectKey := getClusterObjectKey(instance, "apiserver-svc")
+				svc := &corev1.Service{}
+				err := cli.Get(ctx, svcObjectKey, svc)
+				return !apierrors.IsNotFound(err) && svc.Labels["test-label"] == "test"
+			}, time.Minute*2, interval).Should(BeTrue())
+
+			etcdSts := &appsv1.StatefulSet{}
+			By("Control Plane etcd StatefulSet upgraded")
+			Eventually(func() bool {
+				stsObjectKey := getClusterObjectKey(instance, "etcd")
+				err := cli.Get(ctx, stsObjectKey, etcdSts)
+				return !apierrors.IsNotFound(err) && etcdSts.Spec.Template.Spec.Containers[0].Args[0] == "-debug"
+			}, time.Minute*2, interval).Should(BeTrue())
+
+			apiserverSts := &appsv1.StatefulSet{}
+			By("Control Plane apiserver StatefulSet upgraded")
+			Eventually(func() bool {
+				stsObjectKey := getClusterObjectKey(instance, "apiserver")
+				err := cli.Get(ctx, stsObjectKey, apiserverSts)
+				return !apierrors.IsNotFound(err) && apiserverSts.Spec.Template.Spec.Containers[0].Args[0] == "-v=7"
+			}, time.Minute*2, interval).Should(BeTrue())
+
+			cmSts := &appsv1.StatefulSet{}
+			By("Control Plane controller-manager StatefulSet upgraded")
+			Eventually(func() bool {
+				stsObjectKey := getClusterObjectKey(instance, "controller-manager")
+				err := cli.Get(ctx, stsObjectKey, cmSts)
+				return !apierrors.IsNotFound(err) && cmSts.Spec.Template.Spec.Containers[0].Args[0] == "-v=7"
+			}, time.Minute*2, interval).Should(BeTrue())
+		})
+		It("Should delete cluster", func() {
 			By("Deleting VirtualCluster")
-			Expect(cli.Delete(ctx, instance)).To(BeNil())
+			Expect(cli.Delete(context.TODO(), instance)).To(BeNil())
 		})
 	})
 })

--- a/virtualcluster/pkg/controller/controllers/virtualcluster_controller_test.go
+++ b/virtualcluster/pkg/controller/controllers/virtualcluster_controller_test.go
@@ -179,7 +179,6 @@ var _ = Describe("VirtualCluster Controller", func() {
 			}, time.Minute*5, interval).Should(BeTrue())
 
 			By("Updating ClusterVersion")
-			cvInstance.Spec.ETCD.StatefulSet.Spec.Template.Spec.Containers[0].Args = append([]string{"-debug"}, cvInstance.Spec.ETCD.StatefulSet.Spec.Template.Spec.Containers[0].Args...)
 			cvInstance.Spec.APIServer.StatefulSet.Spec.Template.Spec.Containers[0].Args = append([]string{"-v=7"}, cvInstance.Spec.APIServer.StatefulSet.Spec.Template.Spec.Containers[0].Args...)
 			if cvInstance.Spec.APIServer.Service.Labels == nil {
 				cvInstance.Spec.APIServer.Service.Labels = map[string]string{}
@@ -201,14 +200,6 @@ var _ = Describe("VirtualCluster Controller", func() {
 				svc := &corev1.Service{}
 				err := cli.Get(ctx, svcObjectKey, svc)
 				return !apierrors.IsNotFound(err) && svc.Labels["test-label"] == "test"
-			}, time.Minute*2, interval).Should(BeTrue())
-
-			etcdSts := &appsv1.StatefulSet{}
-			By("Control Plane etcd StatefulSet upgraded")
-			Eventually(func() bool {
-				stsObjectKey := getClusterObjectKey(instance, "etcd")
-				err := cli.Get(ctx, stsObjectKey, etcdSts)
-				return !apierrors.IsNotFound(err) && etcdSts.Spec.Template.Spec.Containers[0].Args[0] == "-debug"
 			}, time.Minute*2, interval).Should(BeTrue())
 
 			apiserverSts := &appsv1.StatefulSet{}

--- a/virtualcluster/pkg/controller/pki/pki.go
+++ b/virtualcluster/pkg/controller/pki/pki.go
@@ -242,6 +242,14 @@ func EncodePrivateKeyPEM(key *rsa.PrivateKey) []byte {
 	return pem.EncodeToMemory(&block)
 }
 
+func DecodePrivateKeyPEM(raw []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode private key")
+	}
+	return x509.ParsePKCS1PrivateKey(block.Bytes)
+}
+
 // newPrivateKey creates an RSA private key
 func newPrivateKey() (*rsa.PrivateKey, error) {
 	return rsa.GenerateKey(cryptorand.Reader, 2048)

--- a/virtualcluster/pkg/controller/secret/secret.go
+++ b/virtualcluster/pkg/controller/secret/secret.go
@@ -18,6 +18,8 @@ package secret
 
 import (
 	"crypto/rsa"
+	"crypto/sha256"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,6 +44,14 @@ const (
 	// ServiceAccountSecretName name of the secret with ServiceAccount rsa
 	ServiceAccountSecretName = "serviceaccount-rsa"
 )
+
+// GetHash hashes object to sha256 for annotations
+func GetHash(o interface{}) string {
+	h := sha256.New()
+	h.Write([]byte(fmt.Sprintf("%v", o)))
+
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
 
 // RsaKeyToSecret encapsulates rsaKey into a secret object
 func RsaKeyToSecret(name, namespace string, rsaKey *rsa.PrivateKey) (*corev1.Secret, error) {

--- a/virtualcluster/pkg/controller/secret/secret.go
+++ b/virtualcluster/pkg/controller/secret/secret.go
@@ -50,6 +50,10 @@ func RsaKeyToSecret(name, namespace string, rsaKey *rsa.PrivateKey) (*corev1.Sec
 		return nil, err
 	}
 	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -65,6 +69,10 @@ func RsaKeyToSecret(name, namespace string, rsaKey *rsa.PrivateKey) (*corev1.Sec
 // CrtKeyPairToSecret encapsulates ca/key pair ckp into a secret object
 func CrtKeyPairToSecret(name, namespace string, ckp *vcpki.CrtKeyPair) *corev1.Secret {
 	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -80,6 +88,10 @@ func CrtKeyPairToSecret(name, namespace string, ckp *vcpki.CrtKeyPair) *corev1.S
 // KubeconfigToSecret encapsulates kubeconfig cfgContent into a secret object
 func KubeconfigToSecret(name, namespace string, cfgContent string) *corev1.Secret {
 	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,

--- a/virtualcluster/pkg/syncer/constants/constants.go
+++ b/virtualcluster/pkg/syncer/constants/constants.go
@@ -50,6 +50,14 @@ const (
 	// LabelVCRootNS means the namespace is the rootns created by vc-manager.
 	LabelVCRootNS = "tenancy.x-k8s.io/vcrootns"
 
+	// LabelVCReadyForUpgrade is set to "true" when the cluster is ready for the upgrade being applied
+	// (use featuregate.VirtualClusterApplyUpdate to enable it in the provisioner)
+	LabelVCReadyForUpgrade = "tenancy.x-k8s.io/ready-for-upgrade"
+
+	// LabelClusterVersionApplied should be set equal to the ClusterVersion.metadata.resourceVersion value
+	// This label is used in featuregate.VirtualClusterApplyUpdate to compare if the update must be applied.
+	LabelClusterVersionApplied = "tenancy.x-k8s.io/cluster-version-applied"
+
 	// LabelExternalApiserverDomain is the domain name for apiserver url from outside the cluster
 	LabelExternalApiserverDomain = "tenancy.x-k8s.io/external-apiserver-domain"
 

--- a/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -65,20 +65,20 @@ const (
 	// accessed by the PodIP on each pod on the node
 	VNodeProviderPodIP = "VNodeProviderPodIP"
 
-	// ClusterVersionApplyCurrentState is an experimental feature that allows the cluster provisioner
+	// ClusterVersionPartialUpgrade is an experimental feature that allows the cluster provisioner
 	// to apply ClusterVersion updates if VirtualCluster object is requested it
-	ClusterVersionApplyCurrentState = "ClusterVersionApplyCurrentState"
+	ClusterVersionPartialUpgrade = "ClusterVersionPartialUpgrade"
 )
 
 var defaultFeatures = FeatureList{
-	SuperClusterPooling:             {Default: false},
-	SuperClusterServiceNetwork:      {Default: false},
-	SuperClusterLabelling:           {Default: false},
-	SuperClusterLabelFilter:         {Default: false},
-	VNodeProviderService:            {Default: false},
-	TenantAllowDNSPolicy:            {Default: false},
-	VNodeProviderPodIP:              {Default: false},
-	ClusterVersionApplyCurrentState: {Default: false},
+	SuperClusterPooling:          {Default: false},
+	SuperClusterServiceNetwork:   {Default: false},
+	SuperClusterLabelling:        {Default: false},
+	SuperClusterLabelFilter:      {Default: false},
+	VNodeProviderService:         {Default: false},
+	TenantAllowDNSPolicy:         {Default: false},
+	VNodeProviderPodIP:           {Default: false},
+	ClusterVersionPartialUpgrade: {Default: false},
 }
 
 type Feature string

--- a/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -64,6 +64,10 @@ const (
 	// vn-agent to run as a daemonset but run without hostNetworking and
 	// accessed by the PodIP on each pod on the node
 	VNodeProviderPodIP = "VNodeProviderPodIP"
+
+	// VirtualClusterApplyUpdate is an experimental feature that allows the cluster provisioner
+	// to apply ClusterVersion updates if VirtualCluster object is requested it
+	VirtualClusterApplyUpdate = "VirtualClusterApplyUpdate"
 )
 
 var defaultFeatures = FeatureList{
@@ -74,6 +78,7 @@ var defaultFeatures = FeatureList{
 	VNodeProviderService:       {Default: false},
 	TenantAllowDNSPolicy:       {Default: false},
 	VNodeProviderPodIP:         {Default: false},
+	VirtualClusterApplyUpdate:  {Default: false},
 }
 
 type Feature string

--- a/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -65,20 +65,20 @@ const (
 	// accessed by the PodIP on each pod on the node
 	VNodeProviderPodIP = "VNodeProviderPodIP"
 
-	// VirtualClusterApplyUpdate is an experimental feature that allows the cluster provisioner
+	// ClusterVersionApplyCurrentState is an experimental feature that allows the cluster provisioner
 	// to apply ClusterVersion updates if VirtualCluster object is requested it
-	VirtualClusterApplyUpdate = "VirtualClusterApplyUpdate"
+	ClusterVersionApplyCurrentState = "ClusterVersionApplyCurrentState"
 )
 
 var defaultFeatures = FeatureList{
-	SuperClusterPooling:        {Default: false},
-	SuperClusterServiceNetwork: {Default: false},
-	SuperClusterLabelling:      {Default: false},
-	SuperClusterLabelFilter:    {Default: false},
-	VNodeProviderService:       {Default: false},
-	TenantAllowDNSPolicy:       {Default: false},
-	VNodeProviderPodIP:         {Default: false},
-	VirtualClusterApplyUpdate:  {Default: false},
+	SuperClusterPooling:             {Default: false},
+	SuperClusterServiceNetwork:      {Default: false},
+	SuperClusterLabelling:           {Default: false},
+	SuperClusterLabelFilter:         {Default: false},
+	VNodeProviderService:            {Default: false},
+	TenantAllowDNSPolicy:            {Default: false},
+	VNodeProviderPodIP:              {Default: false},
+	ClusterVersionApplyCurrentState: {Default: false},
 }
 
 type Feature string

--- a/virtualcluster/pkg/util/pki/util.go
+++ b/virtualcluster/pkg/util/pki/util.go
@@ -25,6 +25,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math"
 	"math/big"
 	"time"
@@ -133,6 +134,14 @@ func EncodeCertPEM(cert *x509.Certificate) []byte {
 		Bytes: cert.Raw,
 	}
 	return pem.EncodeToMemory(&block)
+}
+
+func DecodeCertPEM(raw []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode certificate")
+	}
+	return x509.ParseCertificate(block.Bytes)
 }
 
 // EncodePublicKeyPEM returns PEM-encoded public data


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR adds the featureGate `ClusterVersionPartialUpgrade` to allow native provide to reconcile currently running virtual clusters to re-apply clusterversion specs to control plane.

### Changes to the default behaviour or code
The PR introduces changes to the current native provisioner (Aliyun just returns `not implemented` for the feature):
1. Use serverSide Apply instead of Create means we can reuse methods to re-apply state, instead of breaking with AlreadyExists conflicts. 
2. Kubernetes client requests are finally share the current context instead of TODO().
3. ClusterVersion must contain apiVersion and kind for each Service and StatefulSet defined (it exists in tests, but could be omitted in real world. Using Patch require them to be set)

### Features of the featureGate
1. The change requires control plane statefulsets to have RollingUpdateStatefulSetStrategyType instead of OnDelete to allow rollouts after upgrade.
2. APIServer and ControllerManager do not watch certificates changes on disk, so the statefulsets are annotated to force pod recreation if the certificates changed. In real, the certificates are refreshed in each upgrade, while RootCA remains untouched.
3. ETCD is already reloads certificates from the disk, so it does not need to be annotated
4. Two metrics introduced:
```
# HELP clusters_upgrade_seconds Duration of cluster upgrade by reconciler in featuregate.ClusterVersionPartialUpgrade
# TYPE clusters_upgrade_seconds histogram
clusters_upgrade_seconds_bucket{cluster_version="v1.19-test",resource_version="857463552",le="10"} 1
clusters_upgrade_seconds_bucket{cluster_version="v1.19-test",resource_version="857463552",le="+Inf"} 1
clusters_upgrade_seconds_sum{cluster_version="v1.19-test",resource_version="857463552"} 7.5169857780000005
clusters_upgrade_seconds_count{cluster_version="v1.19-test",resource_version="857463552"} 1
# HELP clusters_upgraded Amount of clusters upgraded by reconciler in featuregate.ClusterVersionPartialUpgrade
# TYPE clusters_upgraded counter
clusters_upgraded{cluster_version="v1.19-test",resource_version="857463552"} 1
```