### PR TITLE
🌱 Upgrade golangci-lint to v1.47.2 and fix its issues

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,5 +19,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.47.1
+          version: v1.47.2
           working-directory: ${{matrix.working-directory}}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version: 1.17
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.1.0
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.44.0
+          version: v1.47.1
           working-directory: ${{matrix.working-directory}}

--- a/virtualcluster/.golangci.yml
+++ b/virtualcluster/.golangci.yml
@@ -12,6 +12,7 @@ linters:
   - gocritic
   - gocyclo
   - gofmt
+  - goheader
   - goimports
   - goprintffuncname
   - gosec
@@ -56,6 +57,29 @@ linters-settings:
       # Controller Runtime
       - pkg: sigs.k8s.io/controller-runtime
         alias: ctrl
+  goheader:
+    values:
+      const:
+        AUTHOR: The Kubernetes Authors
+      regexp:
+        LICENSE_YEAR: 20\d\d
+        SCHEME: http(s)?
+    # The template use for checking.
+    # Default: ""
+    template: |-
+      Copyright {{ LICENSE_YEAR }} {{ AUTHOR }}.
+      
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+      
+          {{ SCHEME }}://www.apache.org/licenses/LICENSE-2.0
+      
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
 
 issues:
   max-same-issues: 0
@@ -120,7 +144,7 @@ issues:
     text: "appendAssign: append result not assigned to the same slice"
 
 run:
-  timeout: 10m
+  timeout: 20m
   skip-files:
   - "zz_generated.*\\.go$"
   - ".*conversion.*\\.go$"

--- a/virtualcluster/cmd/vn-agent/app/server.go
+++ b/virtualcluster/cmd/vn-agent/app/server.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"k8s.io/apiserver/pkg/server/healthz"
 
@@ -98,8 +99,9 @@ func Run(c *config.Config, serverOption *options.ServerOption, stopCh <-chan str
 	}
 
 	s := &http.Server{
-		Addr:    fmt.Sprintf(":%d", serverOption.Port),
-		Handler: handler,
+		Addr:              fmt.Sprintf(":%d", serverOption.Port),
+		Handler:           handler,
+		ReadHeaderTimeout: time.Minute,
 		TLSConfig: &tls.Config{
 			ClientAuth: tls.RequestClientCert,
 			MinVersion: tls.VersionTLS12,

--- a/virtualcluster/pkg/controller/controllers/metrics.go
+++ b/virtualcluster/pkg/controller/controllers/metrics.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers
 
 import (

--- a/virtualcluster/pkg/controller/util/net/util.go
+++ b/virtualcluster/pkg/controller/util/net/util.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package net
 
 import (

--- a/virtualcluster/pkg/syncer/resources/configmap/checker.go
+++ b/virtualcluster/pkg/syncer/resources/configmap/checker.go
@@ -1,10 +1,11 @@
 /*
 Copyright 2021 The Kubernetes Authors.
- Licensed under the Apache License, Version 2.0 (the "License");
+
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/virtualcluster/pkg/syncer/resources/crd/checker.go
+++ b/virtualcluster/pkg/syncer/resources/crd/checker.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2021 The Kubernetes Authors.
- Licensed under the Apache License, Version 2.0 (the "License");
+
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-     http://www.apache.org/licenses/LICENSE-2.0
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/pkg/syncer/resources/crd/controller.go
+++ b/virtualcluster/pkg/syncer/resources/crd/controller.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2021 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/pkg/syncer/resources/endpoints/checker.go
+++ b/virtualcluster/pkg/syncer/resources/endpoints/checker.go
@@ -1,10 +1,11 @@
 /*
 Copyright 2019 The Kubernetes Authors.
- Licensed under the Apache License, Version 2.0 (the "License");
+
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/virtualcluster/pkg/syncer/resources/ingress/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/ingress/checker_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/pkg/syncer/resources/namespace/checker.go
+++ b/virtualcluster/pkg/syncer/resources/namespace/checker.go
@@ -1,10 +1,11 @@
 /*
 Copyright 2019 The Kubernetes Authors.
- Licensed under the Apache License, Version 2.0 (the "License");
+
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/virtualcluster/pkg/syncer/resources/persistentvolume/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolume/checker_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/pkg/syncer/resources/pod/validationplugin/interface.go
+++ b/virtualcluster/pkg/syncer/resources/pod/validationplugin/interface.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2022 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/pkg/syncer/resources/priorityclass/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/priorityclass/checker_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/pkg/syncer/resources/service/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/service/checker_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
+++ b/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
@@ -1,10 +1,11 @@
 /*
 Copyright 2019 The Kubernetes Authors.
- Licensed under the Apache License, Version 2.0 (the "License");
+
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/virtualcluster/pkg/syncer/resources/serviceaccount/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/serviceaccount/checker_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/pkg/syncer/resources/storageclass/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/storageclass/checker_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/test/e2e/e2e.go
+++ b/virtualcluster/test/e2e/e2e.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/test/e2e/e2e_test.go
+++ b/virtualcluster/test/e2e/e2e_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/test/e2e/framework/framework.go
+++ b/virtualcluster/test/e2e/framework/framework.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/test/e2e/framework/text_context.go
+++ b/virtualcluster/test/e2e/framework/text_context.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/test/e2e/framework/util.go
+++ b/virtualcluster/test/e2e/framework/util.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/virtualcluster/test/e2e/framework/vc.go
+++ b/virtualcluster/test/e2e/framework/vc.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR upgrade golangci-lint to the latest and fixes the issues found in it

https://github.com/golangci/golangci-lint/pull/2999

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #291
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-nested/pull/290#discussion_r925997669 and adds the goheader linter to catch Copyright issues
