### PR TITLE
🐛 Resource already exists and the UID is different should not requeue

### DIFF
--- a/virtualcluster/pkg/syncer/resources/configmap/dws.go
+++ b/virtualcluster/pkg/syncer/resources/configmap/dws.go
@@ -96,9 +96,10 @@ func (c *controller) reconcileConfigMapCreate(clusterName, targetNamespace, requ
 	if apierrors.IsAlreadyExists(err) {
 		if pConfigMap.Annotations[constants.LabelUID] == requestUID {
 			klog.Infof("configmap %s/%s of cluster %s already exist in super control plane", targetNamespace, configMap.Name, clusterName)
-			return nil
+		} else {
+			klog.Errorf("pConfigMap %s/%s exists but its delegated object UID is different", targetNamespace, pConfigMap.Name)
 		}
-		return fmt.Errorf("pConfigMap %s/%s exists but its delegated object UID is different", targetNamespace, pConfigMap.Name)
+		return nil
 	}
 	return err
 }

--- a/virtualcluster/pkg/syncer/resources/endpoints/dws.go
+++ b/virtualcluster/pkg/syncer/resources/endpoints/dws.go
@@ -108,9 +108,10 @@ func (c *controller) reconcileEndpointsCreate(clusterName, targetNamespace, requ
 	if apierrors.IsAlreadyExists(err) {
 		if pEndpoints.Annotations[constants.LabelUID] == requestUID {
 			klog.Infof("endpoints %s/%s of cluster %s already exist in super control plane", targetNamespace, pEndpoints.Name, clusterName)
-			return nil
+		} else {
+			klog.Errorf("pEndpoints %s/%s exists but its delegated object UID is different", targetNamespace, pEndpoints.Name)
 		}
-		return fmt.Errorf("pEndpoints %s/%s exists but its delegated object UID is different", targetNamespace, pEndpoints.Name)
+		return nil
 	}
 	return err
 }

--- a/virtualcluster/pkg/syncer/resources/ingress/dws.go
+++ b/virtualcluster/pkg/syncer/resources/ingress/dws.go
@@ -96,9 +96,10 @@ func (c *controller) reconcileIngressCreate(clusterName, targetNamespace, reques
 	if apierrors.IsAlreadyExists(err) {
 		if pIngress.Annotations[constants.LabelUID] == requestUID {
 			klog.Infof("ingress %s/%s of cluster %s already exist in super control plane", targetNamespace, pIngress.Name, clusterName)
-			return nil
+		} else {
+			klog.Errorf("pIngress %s/%s exists but its delegated object UID is different", targetNamespace, pIngress.Name)
 		}
-		return fmt.Errorf("pIngress %s/%s exists but its delegated object UID is different", targetNamespace, pIngress.Name)
+		return nil
 	}
 	return err
 }

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/dws.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/dws.go
@@ -98,9 +98,10 @@ func (c *controller) reconcilePVCCreate(clusterName, targetNamespace, requestUID
 	if apierrors.IsAlreadyExists(err) {
 		if pPVC.Annotations[constants.LabelUID] == requestUID {
 			klog.Infof("pvc %s/%s of cluster %s already exist in super control plane", targetNamespace, pPVC.Name, clusterName)
-			return nil
+		} else {
+			klog.Errorf("pPVC %s/%s exists but its delegated object UID is different", targetNamespace, pPVC.Name)
 		}
-		return fmt.Errorf("pPVC %s/%s exists but its delegated object UID is different", targetNamespace, pPVC.Name)
+		return nil
 	}
 	return err
 }

--- a/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -236,9 +236,10 @@ func (c *controller) reconcilePodCreate(clusterName, targetNamespace, requestUID
 	if apierrors.IsAlreadyExists(err) {
 		if pPod.Annotations[constants.LabelUID] == requestUID {
 			klog.Infof("pod %s/%s of cluster %s already exist in super control plane", targetNamespace, pPod.Name, clusterName)
-			return nil
+		} else {
+			klog.Errorf("pPod %s/%s exists but the UID is different from tenant control plane", targetNamespace, pPod.Name)
 		}
-		return fmt.Errorf("pPod %s/%s exists but the UID is different from tenant control plane", targetNamespace, pPod.Name)
+		return nil
 	}
 
 	return err

--- a/virtualcluster/pkg/syncer/resources/secret/dws.go
+++ b/virtualcluster/pkg/syncer/resources/secret/dws.go
@@ -161,9 +161,10 @@ func (c *controller) reconcileNormalSecretCreate(clusterName, targetNamespace, r
 	if apierrors.IsAlreadyExists(err) {
 		if pSecret.Annotations[constants.LabelUID] == requestUID {
 			klog.Infof("secret %s/%s of cluster %s already exist in super control plane", targetNamespace, secret.Name, clusterName)
-			return nil
+		} else {
+			klog.Errorf("pSecret %s/%s exists but its delegated object UID is different", targetNamespace, pSecret.Name)
 		}
-		return fmt.Errorf("pSecret %s/%s exists but its delegated object UID is different", targetNamespace, pSecret.Name)
+		return nil
 	}
 
 	return err

--- a/virtualcluster/pkg/syncer/resources/service/dws.go
+++ b/virtualcluster/pkg/syncer/resources/service/dws.go
@@ -96,9 +96,10 @@ func (c *controller) reconcileServiceCreate(clusterName, targetNamespace, reques
 	if apierrors.IsAlreadyExists(err) {
 		if pService.Annotations[constants.LabelUID] == requestUID {
 			klog.Infof("service %s/%s of cluster %s already exist in super control plane", targetNamespace, pService.Name, clusterName)
-			return nil
+		} else {
+			klog.Errorf("pService %s/%s exists but its delegated object UID is different", targetNamespace, pService.Name)
 		}
-		return fmt.Errorf("pService %s/%s exists but its delegated object UID is different", targetNamespace, pService.Name)
+		return nil
 	}
 	return err
 }

--- a/virtualcluster/pkg/syncer/resources/serviceaccount/dws.go
+++ b/virtualcluster/pkg/syncer/resources/serviceaccount/dws.go
@@ -98,9 +98,10 @@ func (c *controller) reconcileServiceAccountCreate(clusterName, targetNamespace,
 	if apierrors.IsAlreadyExists(err) {
 		if pServiceAccount.Annotations[constants.LabelUID] == requestUID {
 			klog.Infof("service account %s/%s of cluster %s already exist in super control plane", targetNamespace, pServiceAccount.Name, clusterName)
-			return nil
+		} else {
+			klog.Errorf("pServiceAccount %s/%s exists but its delegated UID is different", targetNamespace, pServiceAccount.Name)
 		}
-		return fmt.Errorf("pServiceAccount %s/%s exists but its delegated UID is different", targetNamespace, pServiceAccount.Name)
+		return nil
 	}
 	return err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If the queue is not dequeued so early, the abnormal tasks will continue to accumulate until they exceed the maximum number of retries MaxReconcileRetryAttempts will be discarded.

So, when the DWS synchronization resource is encountered but its delegated object UID is different in the reconcileXXXCreate process, it should not re-enter the queue, because the event will also not be processed in the subsequent process.

**Which issue(s) this PR fixes**:
Fixes #293