### PR TITLE
🌱 Update CRD Clients to v1

### DIFF
--- a/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/virtualcluster/pkg/syncer/conversion/equality.go
@@ -19,12 +19,11 @@ package conversion
 import (
 	"strings"
 
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-
 	v1 "k8s.io/api/core/v1"
 	v1beta1extensions "k8s.io/api/extensions/v1beta1"
 	v1scheduling "k8s.io/api/scheduling/v1"
 	v1storage "k8s.io/api/storage/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -628,7 +627,7 @@ func (e vcEquality) CheckPriorityClassEquality(pObj, vObj *v1scheduling.Priority
 	}
 }
 
-func (e vcEquality) CheckCRDEquality(pObj, vObj *v1beta1.CustomResourceDefinition) *v1beta1.CustomResourceDefinition {
+func (e vcEquality) CheckCRDEquality(pObj, vObj *apiextensionsv1.CustomResourceDefinition) *apiextensionsv1.CustomResourceDefinition {
 	pObjCopy := pObj.DeepCopy()
 	pObjCopy.ObjectMeta = vObj.ObjectMeta
 	pObjCopy.TypeMeta = vObj.TypeMeta

--- a/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/virtualcluster/pkg/syncer/conversion/helper.go
@@ -29,7 +29,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	v1scheduling "k8s.io/api/scheduling/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -303,7 +303,7 @@ func BuildVirtualPriorityClass(cluster string, pPriorityClass *v1scheduling.Prio
 	return vPriorityClass
 }
 
-func BuildVirtualCRD(cluster string, pCRD *v1beta1.CustomResourceDefinition) *v1beta1.CustomResourceDefinition {
+func BuildVirtualCRD(cluster string, pCRD *apiextensionsv1.CustomResourceDefinition) *apiextensionsv1.CustomResourceDefinition {
 	vCRD := pCRD.DeepCopy()
 	ResetMetadata(vCRD)
 	return vCRD

--- a/virtualcluster/pkg/syncer/resources/crd/uws.go
+++ b/virtualcluster/pkg/syncer/resources/crd/uws.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiextensionclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	apiextensionclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -53,7 +53,7 @@ func (c *controller) BackPopulate(key string) error {
 	// The key format is clustername/pcName.
 	clusterName, crdName, _ := cache.SplitMetaNamespaceKey(key)
 	op := reconciler.AddEvent
-	pCRD := &v1beta1.CustomResourceDefinition{}
+	pCRD := &apiextensionsv1.CustomResourceDefinition{}
 	err := c.superClient.Get(context.TODO(), client.ObjectKey{
 		Name: crdName,
 	}, pCRD)
@@ -74,9 +74,9 @@ func (c *controller) BackPopulate(key string) error {
 	if err != nil {
 		return err
 	}
-	vcapiextensionsClient = vcc.ApiextensionsV1beta1()
+	vcapiextensionsClient = vcc.ApiextensionsV1()
 
-	vCRD := &v1beta1.CustomResourceDefinition{}
+	vCRD := &apiextensionsv1.CustomResourceDefinition{}
 	if err := c.MultiClusterController.Get(clusterName, "", crdName, vCRD); err != nil {
 		if apierrors.IsNotFound(err) {
 			if op == reconciler.AddEvent {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Updates the CRD types to v1 from v1beta1, v1beta1 was deprecated and when using the crd syncer it will fail to boot on anything above v1.20.

Signed-off-by: Chris Hein <me@chrishein.com>