### PR TITLE
🌱 Remove excess NodeInfo.OperatingSystem assign

### DIFF
--- a/virtualcluster/pkg/syncer/vnode/vnode.go
+++ b/virtualcluster/pkg/syncer/vnode/vnode.go
@@ -85,7 +85,6 @@ func NewVirtualNode(provider provider.VirtualNodeProvider, node *corev1.Node) (v
 
 	// fill in status
 	n.Status.Conditions = nodeConditions()
-	n.Status.NodeInfo.OperatingSystem = "Linux"
 	de, err := provider.GetNodeDaemonEndpoints(node)
 	if err != nil {
 		return nil, pkgerr.Wrapf(err, "get node daemon endpoints from provider")


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: The PR removes confusing excess n.Status.NodeInfo.OperatingSystem assign to Linux, which is not used anywhere and is rewritten in a couple of lines later https://github.com/m-messiah/cluster-api-provider-nested/blob/02b288a700d6ef6fd1776f4d63e3e4a7e0ca317c/virtualcluster/pkg/syncer/vnode/vnode.go#L100

