### PR TITLE
🌱 Add etcd.namespace to the etcd certificate

### DIFF
--- a/virtualcluster/pkg/client/clientset/versioned/fake/register.go
+++ b/virtualcluster/pkg/client/clientset/versioned/fake/register.go
@@ -36,14 +36,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/virtualcluster/pkg/client/clientset/versioned/scheme/register.go
+++ b/virtualcluster/pkg/client/clientset/versioned/scheme/register.go
@@ -36,14 +36,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/virtualcluster/pkg/controller/controllers/provisioner/provisioner_native.go
+++ b/virtualcluster/pkg/controller/controllers/provisioner/provisioner_native.go
@@ -369,6 +369,11 @@ func (mpn *Native) createAndApplyPKI(ctx context.Context, vc *tenancyv1alpha1.Vi
 	caGroup.RootCA = rootCAPair
 
 	etcdDomains := append(cv.GetEtcdServers(), cv.GetEtcdDomain())
+	// We may want to connect to etcd from controllers namespace
+	// So we duplicate etcdDomains here with the namespace
+	for _, etcdDomain := range etcdDomains {
+		etcdDomains = append(etcdDomains, etcdDomain+"."+ns)
+	}
 	// create crt, key for etcd
 	etcdCAPair, etcdCrtErr := vcpki.NewEtcdServerCertAndKey(rootCAPair, etcdDomains)
 	if etcdCrtErr != nil {

--- a/virtualcluster/pkg/syncer/resources/namespace/checker.go
+++ b/virtualcluster/pkg/syncer/resources/namespace/checker.go
@@ -48,7 +48,7 @@ func (c *controller) StartPatrol(stopCh <-chan struct{}) error {
 	return nil
 }
 
-//  shouldBeGarbageCollected checks if the owner vc object is deleted or not. If so, the namespace should be garbage collected.
+// shouldBeGarbageCollected checks if the owner vc object is deleted or not. If so, the namespace should be garbage collected.
 func (c *controller) shouldBeGarbageCollected(ns *corev1.Namespace) bool {
 	vcName := ns.Annotations[constants.LabelVCName]
 	vcNamespace := ns.Annotations[constants.LabelVCNamespace]


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently, etcd certificate is valid for `etcd-0.etcd, etcd-1.etcd, etcd-2.etcd, etcd` names only. That prevents us to connect to etcd from controllers to do health checks, upgrade maintenance or backups without using InsecureSkipVerify.
The PR adds virtualcluster namespace to every etcd domain, so they would be accessible
