### PR TITLE
🌱 Update Ingress Syncer for v1.20 support

### DIFF
--- a/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/virtualcluster/pkg/syncer/conversion/equality.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	v1beta1extensions "k8s.io/api/extensions/v1beta1"
+	v1networking "k8s.io/api/networking/v1"
 	v1scheduling "k8s.io/api/scheduling/v1"
 	v1storage "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -640,7 +640,7 @@ func (e vcEquality) CheckCRDEquality(pObj, vObj *apiextensionsv1.CustomResourceD
 	}
 }
 
-func (e vcEquality) CheckIngressEquality(pObj, vObj *v1beta1extensions.Ingress) *v1beta1extensions.Ingress {
+func (e vcEquality) CheckIngressEquality(pObj, vObj *v1networking.Ingress) *v1networking.Ingress {
 	pObjCopy := pObj.DeepCopy()
 	pObjCopy.ObjectMeta = vObj.ObjectMeta
 	// pObj.TypeMeta is empty

--- a/virtualcluster/pkg/syncer/resources/ingress/checker.go
+++ b/virtualcluster/pkg/syncer/resources/ingress/checker.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -82,7 +82,7 @@ func (c *controller) PatrollerDo() {
 			continue
 		}
 		shouldDelete := false
-		vIngress := &v1beta1.Ingress{}
+		vIngress := &networkingv1.Ingress{}
 		err := c.MultiClusterController.Get(clusterName, vNamespace, pIngress.Name, vIngress)
 		if apierrors.IsNotFound(err) {
 			shouldDelete = true
@@ -109,7 +109,7 @@ func (c *controller) PatrollerDo() {
 }
 
 func (c *controller) checkIngressesOfTenantCluster(clusterName string) {
-	ingList := &v1beta1.IngressList{}
+	ingList := &networkingv1.IngressList{}
 	if err := c.MultiClusterController.List(clusterName, ingList); err != nil {
 		klog.Errorf("error listing ingresss from cluster %s informer cache: %v", clusterName, err)
 		return

--- a/virtualcluster/pkg/syncer/resources/ingress/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/ingress/checker_test.go
@@ -19,7 +19,7 @@ package ingress
 import (
 	"testing"
 
-	v1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -150,7 +150,7 @@ func TestIngressPatrol(t *testing.T) {
 						t.Errorf("%s: Unexpected action %s", k, action)
 						continue
 					}
-					created := action.(core.CreateAction).GetObject().(*v1beta1.Ingress)
+					created := action.(core.CreateAction).GetObject().(*networkingv1.Ingress)
 					fullName := created.Namespace + "/" + created.Name
 					if fullName != expectedName {
 						t.Errorf("%s: Expect to create pIngress %s, got %s", k, expectedName, fullName)

--- a/virtualcluster/pkg/syncer/resources/ingress/dws_test.go
+++ b/virtualcluster/pkg/syncer/resources/ingress/dws_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	v1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,11 +33,11 @@ import (
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/conversion"
 )
 
-func tenantIngress(name, namespace, uid string) *v1beta1.Ingress {
-	return &v1beta1.Ingress{
+func tenantIngress(name, namespace, uid string) *networkingv1.Ingress {
+	return &networkingv1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Ingress",
-			APIVersion: "v1beta1",
+			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -47,8 +47,8 @@ func tenantIngress(name, namespace, uid string) *v1beta1.Ingress {
 	}
 }
 
-func superIngress(name, namespace, uid, clusterKey string) *v1beta1.Ingress {
-	return &v1beta1.Ingress{
+func superIngress(name, namespace, uid, clusterKey string) *networkingv1.Ingress {
+	return &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -79,7 +79,7 @@ func TestDWIngressCreation(t *testing.T) {
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
-		ExistingObjectInTenant *v1beta1.Ingress
+		ExistingObjectInTenant *networkingv1.Ingress
 
 		ExpectedCreatedIngresses []string
 		ExpectedError            string
@@ -141,7 +141,7 @@ func TestDWIngressCreation(t *testing.T) {
 				if !action.Matches("create", "ingresses") {
 					t.Errorf("%s: Unexpected action %s", k, action)
 				}
-				createdSVC := action.(core.CreateAction).GetObject().(*v1beta1.Ingress)
+				createdSVC := action.(core.CreateAction).GetObject().(*networkingv1.Ingress)
 				fullName := createdSVC.Namespace + "/" + createdSVC.Name
 				if fullName != expectedName {
 					t.Errorf("%s: Expected %s to be created, got %s", k, expectedName, fullName)
@@ -169,7 +169,7 @@ func TestDWIngressDeletion(t *testing.T) {
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper []runtime.Object
-		EnqueueObject         *v1beta1.Ingress
+		EnqueueObject         *networkingv1.Ingress
 
 		ExpectedDeletedIngresses []string
 		ExpectedError            string
@@ -235,7 +235,7 @@ func TestDWIngressDeletion(t *testing.T) {
 	}
 }
 
-func applySpecToIngress(ing *v1beta1.Ingress, spec *v1beta1.IngressSpec) *v1beta1.Ingress {
+func applySpecToIngress(ing *networkingv1.Ingress, spec *networkingv1.IngressSpec) *networkingv1.Ingress {
 	ing.Spec = *spec.DeepCopy()
 	return ing
 }
@@ -257,31 +257,31 @@ func TestDWIngressUpdate(t *testing.T) {
 	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
 
 	nginx := "nginx"
-	spec1 := &v1beta1.IngressSpec{
+	spec1 := &networkingv1.IngressSpec{
 		IngressClassName: &nginx,
-		Backend: &v1beta1.IngressBackend{
-			ServiceName: "nginx",
+		DefaultBackend: &networkingv1.IngressBackend{
+			Service: &networkingv1.IngressServiceBackend{Name: "nginx"},
 		},
 	}
 
-	spec2 := &v1beta1.IngressSpec{
+	spec2 := &networkingv1.IngressSpec{
 		IngressClassName: &nginx,
-		Backend: &v1beta1.IngressBackend{
-			ServiceName: "nginx",
+		DefaultBackend: &networkingv1.IngressBackend{
+			Service: &networkingv1.IngressServiceBackend{Name: "nginx"},
 		},
 	}
 
 	haproxy := "haproxy"
-	spec3 := &v1beta1.IngressSpec{
+	spec3 := &networkingv1.IngressSpec{
 		IngressClassName: &haproxy,
-		Backend: &v1beta1.IngressBackend{
-			ServiceName: "haproxy",
+		DefaultBackend: &networkingv1.IngressBackend{
+			Service: &networkingv1.IngressServiceBackend{Name: "haproxy"},
 		},
 	}
 
 	testcases := map[string]struct {
 		ExistingObjectInSuper  []runtime.Object
-		ExistingObjectInTenant *v1beta1.Ingress
+		ExistingObjectInTenant *networkingv1.Ingress
 
 		ExpectedUpdatedIngresses []runtime.Object
 		ExpectedError            string


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
When using the ingress syncer and clusters with 1.20+ the ingress API has been moved to v1.20, this causes the syncer to fail. This updates the syncer to use the new API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # <unfiled>


Signed-off-by: Chris Hein <me@chrishein.com>