### PR TITLE
✨ Sync node taints and labels

### DIFF
--- a/virtualcluster/cmd/syncer/app/options/options.go
+++ b/virtualcluster/cmd/syncer/app/options/options.go
@@ -89,6 +89,7 @@ func NewResourceSyncerOptions() (*ResourceSyncerOptions, error) {
 			DisableServiceAccountToken: true,
 			DefaultOpaqueMetaDomains:   []string{"kubernetes.io", "k8s.io"},
 			ExtraSyncingResources:      []string{},
+			ExtraNodeLabels:            []string{},
 			VNAgentPort:                int32(10550),
 			VNAgentNamespacedName:      "vc-manager/vn-agent",
 			VNAgentLabelSelector:       "app=vn-agent",
@@ -125,6 +126,7 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs.StringSliceVar(&o.ComponentConfig.DefaultOpaqueMetaDomains, "default-opaque-meta-domains", o.ComponentConfig.DefaultOpaqueMetaDomains, "DefaultOpaqueMetaDomains is the default opaque meta configuration for each Virtual Cluster.")
 	fs.StringSliceVar(&o.ComponentConfig.ExtraSyncingResources, "extra-syncing-resources", o.ComponentConfig.ExtraSyncingResources, "ExtraSyncingResources defines additional resources that need to be synced for each Virtual Cluster. (priorityclass, ingress, crd)")
 	fs.Var(cliflag.NewMapStringBool(&o.ComponentConfig.FeatureGates), "feature-gates", "A set of key=value pairs that describe featuregate gates for various features.")
+	fs.StringSliceVar(&o.ComponentConfig.ExtraNodeLabels, "extra-node-labels", o.ComponentConfig.ExtraNodeLabels, "ExtraNodeLabels defines additional node labels that need to be synced for each Virtual Cluster")
 	fs.Int32Var(&o.ComponentConfig.VNAgentPort, "vn-agent-port", 10550, "Port the vn-agent listens on")
 	fs.StringVar(&o.ComponentConfig.VNAgentNamespacedName, "vn-agent-namespace-name", "vc-manager/vn-agent", "Namespace/Name of the vn-agent running in cluster, used for VNodeProviderService")
 	fs.Var(cliflag.NewMapStringString(&o.DNSOptions), "dns-options", "DNSOptions is the default DNS options attached to each pod")

--- a/virtualcluster/cmd/syncer/app/options/options.go
+++ b/virtualcluster/cmd/syncer/app/options/options.go
@@ -90,6 +90,7 @@ func NewResourceSyncerOptions() (*ResourceSyncerOptions, error) {
 			DefaultOpaqueMetaDomains:   []string{"kubernetes.io", "k8s.io"},
 			ExtraSyncingResources:      []string{},
 			ExtraNodeLabels:            []string{},
+			OpaqueTaintKeys:            []string{},
 			VNAgentPort:                int32(10550),
 			VNAgentNamespacedName:      "vc-manager/vn-agent",
 			VNAgentLabelSelector:       "app=vn-agent",
@@ -127,6 +128,7 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs.StringSliceVar(&o.ComponentConfig.ExtraSyncingResources, "extra-syncing-resources", o.ComponentConfig.ExtraSyncingResources, "ExtraSyncingResources defines additional resources that need to be synced for each Virtual Cluster. (priorityclass, ingress, crd)")
 	fs.Var(cliflag.NewMapStringBool(&o.ComponentConfig.FeatureGates), "feature-gates", "A set of key=value pairs that describe featuregate gates for various features.")
 	fs.StringSliceVar(&o.ComponentConfig.ExtraNodeLabels, "extra-node-labels", o.ComponentConfig.ExtraNodeLabels, "ExtraNodeLabels defines additional node labels that need to be synced for each Virtual Cluster")
+	fs.StringSliceVar(&o.ComponentConfig.OpaqueTaintKeys, "opaque-taint-keys", o.ComponentConfig.OpaqueTaintKeys, "OpaqueTaintKeys defines taint keys that need to be synced for each Virtual Cluster")
 	fs.Int32Var(&o.ComponentConfig.VNAgentPort, "vn-agent-port", 10550, "Port the vn-agent listens on")
 	fs.StringVar(&o.ComponentConfig.VNAgentNamespacedName, "vn-agent-namespace-name", "vc-manager/vn-agent", "Namespace/Name of the vn-agent running in cluster, used for VNodeProviderService")
 	fs.Var(cliflag.NewMapStringString(&o.DNSOptions), "dns-options", "DNSOptions is the default DNS options attached to each pod")

--- a/virtualcluster/pkg/syncer/apis/config/types.go
+++ b/virtualcluster/pkg/syncer/apis/config/types.go
@@ -62,6 +62,9 @@ type SyncerConfiguration struct {
 	// ExtraNodeLabels is the list of extra labels to be synced to vNode from the super cluster.
 	ExtraNodeLabels []string
 
+	// OpaqueTaintKeys is the list of taint keys to be synced to vNode from the super cluster
+	OpaqueTaintKeys []string
+
 	// VNAgentPort defines the port that the VN Agent is running on per host
 	VNAgentPort int32
 

--- a/virtualcluster/pkg/syncer/apis/config/types.go
+++ b/virtualcluster/pkg/syncer/apis/config/types.go
@@ -59,6 +59,9 @@ type SyncerConfiguration struct {
 	// from syncer which replace the kubelet generated envs.
 	DisablePodServiceLinks bool
 
+	// ExtraNodeLabels is the list of extra labels to be synced to vNode from the super cluster.
+	ExtraNodeLabels []string
+
 	// VNAgentPort defines the port that the VN Agent is running on per host
 	VNAgentPort int32
 

--- a/virtualcluster/pkg/syncer/resources/node/uws.go
+++ b/virtualcluster/pkg/syncer/resources/node/uws.go
@@ -116,7 +116,7 @@ func (c *controller) updateClusterNode(clusterName string, node *corev1.Node, wg
 	}
 	newVNode.Status.DaemonEndpoints = nodeDaemonEndpoints
 
-	newVNode.Spec.Taints = vnode.BuildVNodeTaints(node, metav1.Now())
+	newVNode.Spec.Taints = provider.GetNodeTaints(c.vnodeProvider, node, metav1.Now())
 	newVNode.ObjectMeta.SetLabels(provider.GetNodeLabels(c.vnodeProvider, node))
 
 	if err := vnode.UpdateNode(tenantClient.CoreV1().Nodes(), vNode, newVNode); err != nil {

--- a/virtualcluster/pkg/syncer/resources/node/uws.go
+++ b/virtualcluster/pkg/syncer/resources/node/uws.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/vnode"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/vnode/provider"
 )
 
 // StartUWS starts the upward syncer
@@ -116,6 +117,7 @@ func (c *controller) updateClusterNode(clusterName string, node *corev1.Node, wg
 	newVNode.Status.DaemonEndpoints = nodeDaemonEndpoints
 
 	newVNode.Spec.Taints = vnode.BuildVNodeTaints(node, metav1.Now())
+	newVNode.ObjectMeta.SetLabels(provider.GetNodeLabels(c.vnodeProvider, node))
 
 	if err := vnode.UpdateNode(tenantClient.CoreV1().Nodes(), vNode, newVNode); err != nil {
 		klog.Errorf("failed to update node %s/%s's heartbeats: %v", clusterName, node.Name, err)

--- a/virtualcluster/pkg/syncer/vnode/native/provider.go
+++ b/virtualcluster/pkg/syncer/vnode/native/provider.go
@@ -25,12 +25,13 @@ import (
 type provider struct {
 	vnAgentPort  int32
 	labelsToSync map[string]struct{}
+	taintsToSync map[string]struct{}
 }
 
 var _ vnodeprovider.VirtualNodeProvider = &provider{}
 
-func NewNativeVirtualNodeProvider(vnAgentPort int32, labelsToSync map[string]struct{}) vnodeprovider.VirtualNodeProvider {
-	return &provider{vnAgentPort: vnAgentPort, labelsToSync: labelsToSync}
+func NewNativeVirtualNodeProvider(vnAgentPort int32, labelsToSync, taintsToSync map[string]struct{}) vnodeprovider.VirtualNodeProvider {
+	return &provider{vnAgentPort: vnAgentPort, labelsToSync: labelsToSync, taintsToSync: taintsToSync}
 }
 
 func (p *provider) GetNodeDaemonEndpoints(node *corev1.Node) (corev1.NodeDaemonEndpoints, error) {
@@ -56,4 +57,7 @@ func (p *provider) GetNodeAddress(node *corev1.Node) ([]corev1.NodeAddress, erro
 
 func (p *provider) GetLabelsToSync() map[string]struct{} {
 	return p.labelsToSync
+}
+func (p *provider) GetTaintsToSync() map[string]struct{} {
+	return p.taintsToSync
 }

--- a/virtualcluster/pkg/syncer/vnode/native/provider.go
+++ b/virtualcluster/pkg/syncer/vnode/native/provider.go
@@ -23,13 +23,14 @@ import (
 )
 
 type provider struct {
-	vnAgentPort int32
+	vnAgentPort  int32
+	labelsToSync map[string]struct{}
 }
 
 var _ vnodeprovider.VirtualNodeProvider = &provider{}
 
-func NewNativeVirtualNodeProvider(vnAgentPort int32) vnodeprovider.VirtualNodeProvider {
-	return &provider{vnAgentPort: vnAgentPort}
+func NewNativeVirtualNodeProvider(vnAgentPort int32, labelsToSync map[string]struct{}) vnodeprovider.VirtualNodeProvider {
+	return &provider{vnAgentPort: vnAgentPort, labelsToSync: labelsToSync}
 }
 
 func (p *provider) GetNodeDaemonEndpoints(node *corev1.Node) (corev1.NodeDaemonEndpoints, error) {
@@ -51,4 +52,8 @@ func (p *provider) GetNodeAddress(node *corev1.Node) ([]corev1.NodeAddress, erro
 	}
 
 	return addresses, nil
+}
+
+func (p *provider) GetLabelsToSync() map[string]struct{} {
+	return p.labelsToSync
 }

--- a/virtualcluster/pkg/syncer/vnode/native/provider_test.go
+++ b/virtualcluster/pkg/syncer/vnode/native/provider_test.go
@@ -159,14 +159,14 @@ func Test_provider_GetNodeTaints(t *testing.T) {
 // This method is like https://github.com/kubernetes/kubernetes/blob/v1.21.9/pkg/util/taints/taints.go#L324
 // but only returns bool
 func taintsDiffer(t1, t2 []corev1.Taint) bool {
-	for _, taint := range t1 {
-		if !taintExists(t2, &taint) {
+	for i := range t1 {
+		if !taintExists(t2, &t1[i]) {
 			return true
 		}
 	}
 
-	for _, taint := range t2 {
-		if !taintExists(t1, &taint) {
+	for i := range t2 {
+		if !taintExists(t1, &t2[i]) {
 			return true
 		}
 	}

--- a/virtualcluster/pkg/syncer/vnode/native/provider_test.go
+++ b/virtualcluster/pkg/syncer/vnode/native/provider_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package native
 
 import (

--- a/virtualcluster/pkg/syncer/vnode/native/provider_test.go
+++ b/virtualcluster/pkg/syncer/vnode/native/provider_test.go
@@ -1,0 +1,86 @@
+package native
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vnodeprovider "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/vnode/provider"
+)
+
+func newNode() *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+			Labels: map[string]string{
+				"a": "test-0",
+				"b": "test-1",
+			},
+		},
+	}
+}
+
+func Test_provider_GetNodeLabels(t *testing.T) {
+	type fields struct {
+		labelsToSync map[string]struct{}
+	}
+	type args struct {
+		node *corev1.Node
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[string]string
+	}{
+		{
+			name:   "TestWithNoLabels",
+			fields: fields{},
+			args:   args{newNode()},
+			want: map[string]string{
+				"tenancy.x-k8s.io/virtualnode": "true",
+			},
+		},
+		{
+			name: "TestWithOneLabel",
+			fields: fields{
+				labelsToSync: map[string]struct{}{
+					"a": {},
+				},
+			},
+			args: args{newNode()},
+			want: map[string]string{
+				"tenancy.x-k8s.io/virtualnode": "true",
+				"a":                            "test-0",
+			},
+		},
+		{
+			name: "TestWithManyLabels",
+			fields: fields{
+				labelsToSync: map[string]struct{}{
+					"a": {},
+					"b": {},
+					"c": {},
+				},
+			},
+			args: args{newNode()},
+			want: map[string]string{
+				"tenancy.x-k8s.io/virtualnode": "true",
+				"a":                            "test-0",
+				"b":                            "test-1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewNativeVirtualNodeProvider(8080, tt.fields.labelsToSync)
+			got := vnodeprovider.GetNodeLabels(p, tt.args.node)
+			if len(tt.want) != 0 && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("vnodeprovider.GetNodeLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/virtualcluster/pkg/syncer/vnode/pod/provider.go
+++ b/virtualcluster/pkg/syncer/vnode/pod/provider.go
@@ -38,17 +38,19 @@ type provider struct {
 	vnAgentPort          int32
 	vnAgentNamespaceName string
 	vnAgentLabelSelector string
+	labelsToSync         map[string]struct{}
 	client               clientset.Interface
 }
 
 var _ vnodeprovider.VirtualNodeProvider = &provider{}
 
-func NewPodVirtualNodeProvider(vnAgentPort int32, vnAgentNamespaceName, vnAgentLabelSelector string, client clientset.Interface) vnodeprovider.VirtualNodeProvider {
+func NewPodVirtualNodeProvider(vnAgentPort int32, vnAgentNamespaceName, vnAgentLabelSelector string, client clientset.Interface, labelsToSync map[string]struct{}) vnodeprovider.VirtualNodeProvider {
 	return &provider{
 		vnAgentPort:          vnAgentPort,
 		vnAgentNamespaceName: vnAgentNamespaceName,
 		vnAgentLabelSelector: vnAgentLabelSelector,
 		client:               client,
+		labelsToSync:         labelsToSync,
 	}
 }
 
@@ -85,4 +87,8 @@ func (p *provider) GetNodeAddress(node *corev1.Node) ([]corev1.NodeAddress, erro
 	})
 
 	return addresses, nil
+}
+
+func (p *provider) GetLabelsToSync() map[string]struct{} {
+	return p.labelsToSync
 }

--- a/virtualcluster/pkg/syncer/vnode/pod/provider.go
+++ b/virtualcluster/pkg/syncer/vnode/pod/provider.go
@@ -39,18 +39,20 @@ type provider struct {
 	vnAgentNamespaceName string
 	vnAgentLabelSelector string
 	labelsToSync         map[string]struct{}
+	taintsToSync         map[string]struct{}
 	client               clientset.Interface
 }
 
 var _ vnodeprovider.VirtualNodeProvider = &provider{}
 
-func NewPodVirtualNodeProvider(vnAgentPort int32, vnAgentNamespaceName, vnAgentLabelSelector string, client clientset.Interface, labelsToSync map[string]struct{}) vnodeprovider.VirtualNodeProvider {
+func NewPodVirtualNodeProvider(vnAgentPort int32, vnAgentNamespaceName, vnAgentLabelSelector string, client clientset.Interface, labelsToSync, taintsToSync map[string]struct{}) vnodeprovider.VirtualNodeProvider {
 	return &provider{
 		vnAgentPort:          vnAgentPort,
 		vnAgentNamespaceName: vnAgentNamespaceName,
 		vnAgentLabelSelector: vnAgentLabelSelector,
 		client:               client,
 		labelsToSync:         labelsToSync,
+		taintsToSync:         taintsToSync,
 	}
 }
 
@@ -91,4 +93,8 @@ func (p *provider) GetNodeAddress(node *corev1.Node) ([]corev1.NodeAddress, erro
 
 func (p *provider) GetLabelsToSync() map[string]struct{} {
 	return p.labelsToSync
+}
+
+func (p *provider) GetTaintsToSync() map[string]struct{} {
+	return p.taintsToSync
 }

--- a/virtualcluster/pkg/syncer/vnode/provider/provider.go
+++ b/virtualcluster/pkg/syncer/vnode/provider/provider.go
@@ -24,4 +24,16 @@ import (
 type VirtualNodeProvider interface {
 	GetNodeDaemonEndpoints(node *corev1.Node) (corev1.NodeDaemonEndpoints, error)
 	GetNodeAddress(node *corev1.Node) ([]corev1.NodeAddress, error)
+	GetLabelsToSync() map[string]struct{}
+}
+
+// GetNodeLabels is used to sync allowed node labels to vNode
+func GetNodeLabels(p VirtualNodeProvider, node *corev1.Node, labels map[string]string) map[string]string {
+	labelsToSync := p.GetLabelsToSync()
+	for k, v := range node.GetLabels() {
+		if _, found := labelsToSync[k]; found {
+			labels[k] = v
+		}
+	}
+	return labels
 }

--- a/virtualcluster/pkg/syncer/vnode/provider/provider.go
+++ b/virtualcluster/pkg/syncer/vnode/provider/provider.go
@@ -18,6 +18,10 @@ package provider
 
 import (
 	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/util/featuregate"
+	utilconstants "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/constants"
 )
 
 // VirtualNodeProvider is the interface used for registering the node address.
@@ -28,7 +32,15 @@ type VirtualNodeProvider interface {
 }
 
 // GetNodeLabels is used to sync allowed node labels to vNode
-func GetNodeLabels(p VirtualNodeProvider, node *corev1.Node, labels map[string]string) map[string]string {
+func GetNodeLabels(p VirtualNodeProvider, node *corev1.Node) map[string]string {
+	labels := map[string]string{
+		constants.LabelVirtualNode: "true",
+	}
+
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.SuperClusterPooling) {
+		labels[constants.LabelSuperClusterID] = utilconstants.SuperClusterID
+	}
+
 	labelsToSync := p.GetLabelsToSync()
 	for k, v := range node.GetLabels() {
 		if _, found := labelsToSync[k]; found {

--- a/virtualcluster/pkg/syncer/vnode/service/provider.go
+++ b/virtualcluster/pkg/syncer/vnode/service/provider.go
@@ -31,15 +31,17 @@ type provider struct {
 	vnAgentPort          int32
 	vnAgentNamespaceName string
 	client               clientset.Interface
+	labelsToSync         map[string]struct{}
 }
 
 var _ vnodeprovider.VirtualNodeProvider = &provider{}
 
-func NewServiceVirtualNodeProvider(vnAgentPort int32, vnAgentNamespaceName string, client clientset.Interface) vnodeprovider.VirtualNodeProvider {
+func NewServiceVirtualNodeProvider(vnAgentPort int32, vnAgentNamespaceName string, client clientset.Interface, labelsToSync map[string]struct{}) vnodeprovider.VirtualNodeProvider {
 	return &provider{
 		vnAgentPort:          vnAgentPort,
 		vnAgentNamespaceName: vnAgentNamespaceName,
 		client:               client,
+		labelsToSync:         labelsToSync,
 	}
 }
 
@@ -64,4 +66,8 @@ func (p *provider) GetNodeAddress(node *corev1.Node) ([]corev1.NodeAddress, erro
 		Address: svc.Spec.ClusterIP,
 	})
 	return addresses, nil
+}
+
+func (p *provider) GetLabelsToSync() map[string]struct{} {
+	return p.labelsToSync
 }

--- a/virtualcluster/pkg/syncer/vnode/service/provider.go
+++ b/virtualcluster/pkg/syncer/vnode/service/provider.go
@@ -32,16 +32,18 @@ type provider struct {
 	vnAgentNamespaceName string
 	client               clientset.Interface
 	labelsToSync         map[string]struct{}
+	taintsToSync         map[string]struct{}
 }
 
 var _ vnodeprovider.VirtualNodeProvider = &provider{}
 
-func NewServiceVirtualNodeProvider(vnAgentPort int32, vnAgentNamespaceName string, client clientset.Interface, labelsToSync map[string]struct{}) vnodeprovider.VirtualNodeProvider {
+func NewServiceVirtualNodeProvider(vnAgentPort int32, vnAgentNamespaceName string, client clientset.Interface, labelsToSync, taintsToSync map[string]struct{}) vnodeprovider.VirtualNodeProvider {
 	return &provider{
 		vnAgentPort:          vnAgentPort,
 		vnAgentNamespaceName: vnAgentNamespaceName,
 		client:               client,
 		labelsToSync:         labelsToSync,
+		taintsToSync:         taintsToSync,
 	}
 }
 
@@ -70,4 +72,8 @@ func (p *provider) GetNodeAddress(node *corev1.Node) ([]corev1.NodeAddress, erro
 
 func (p *provider) GetLabelsToSync() map[string]struct{} {
 	return p.labelsToSync
+}
+
+func (p *provider) GetTaintsToSync() map[string]struct{} {
+	return p.taintsToSync
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: 

***Context***:

The main reason for these changes is to allow VirtualCluster users to use pod.Spec.NodeSelector in their pods and choose nodes they want to be assigned. This would be extended after to auto-apply this nodeSelector for all pods in syncer if we want to have VirtualCluster fully isolated on the subset of nodes.

***Technical description***:

The PR adds sync of node Taints from super cluster to VirtualCluster to allow VirtualCluster pods to have tolerations.
The PR also extends the list of node labels to be synced to VirtualCluster, providing a new flag `--extra-node-labels=<stringslice>` to allow an operator to set the list of labels that need to be accessible by VirtualCluster users and used by them as node selectors.

***Tests***:

The change was tested by passing `--extra-node-labels=node-selectors/default,test-label` to the syncer, creating VirtualCluster with a pod and checking node labels in node from inside the VirtualCluster. 
I also edited super-cluster node labels and it was successfully synced to the VirtualCluster.