### PR TITLE
🐛 Handle GetCluster == nil in CRD uws

### DIFF
--- a/virtualcluster/pkg/syncer/resources/crd/checker.go
+++ b/virtualcluster/pkg/syncer/resources/crd/checker.go
@@ -97,7 +97,13 @@ func (c *controller) checkCRDOfTenantCluster(clusterName string) {
 		return
 	}
 
-	vcrestconfig := c.MultiClusterController.GetCluster(clusterName).GetRestConfig()
+	cluster := c.MultiClusterController.GetCluster(clusterName)
+	if cluster == nil {
+		klog.Errorf("cannot get virtual cluster")
+		return
+	}
+
+	vcrestconfig := cluster.GetRestConfig()
 	var vcapiextensionsClient apiextensionclientset.CustomResourceDefinitionsGetter
 
 	if vcrestconfig == nil {

--- a/virtualcluster/pkg/syncer/resources/crd/uws.go
+++ b/virtualcluster/pkg/syncer/resources/crd/uws.go
@@ -31,6 +31,7 @@ import (
 
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/conversion"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/errors"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/reconciler"
 )
 
@@ -64,7 +65,12 @@ func (c *controller) BackPopulate(key string) error {
 		op = reconciler.DeleteEvent
 	}
 
-	vcrestconfig := c.MultiClusterController.GetCluster(clusterName).GetRestConfig()
+	cluster := c.MultiClusterController.GetCluster(clusterName)
+	if cluster == nil {
+		return errors.NewClusterNotFound(clusterName)
+	}
+
+	vcrestconfig := cluster.GetRestConfig()
 	var vcapiextensionsClient apiextensionclientset.CustomResourceDefinitionsGetter
 
 	if vcrestconfig == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

`c.MultiClusterController.GetCluster` method returns a pointer, but nil check was not done, so sometimes we could see the panic in logs, resulting syncer to be restarted or completely broken in that loop.

```
E0915 11:20:03.699391       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 6354 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1b6d040?, 0x30ce4b0})
	/go/pkg/mod/k8s.io/apimachinery@v0.21.1/pkg/util/runtime/runtime.go:74 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc18faa20d0?})
	/go/pkg/mod/k8s.io/apimachinery@v0.21.1/pkg/util/runtime/runtime.go:48 +0x75
panic({0x1b6d040, 0x30ce4b0})
	/usr/local/go/src/runtime/panic.go:884 +0x212
sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/resources/crd.(*controller).BackPopulate(0xc0007f4480, {0xc18836d5e0?, 0xc18faa20d0?})
	/go/pkg/mod/sigs.k8s.io/cluster-api-provider-nested/virtualcluster@v0.0.0-20220825091205-ef058637a56e/pkg/syncer/resources/crd/uws.go:67 +0x149
...
```

The PR just adds a non-nil check for the object as it is already done in other invocations of the method