### PR TITLE
🐛 Fix cancelFunc on cluster init and fix node Patch

### DIFF
--- a/virtualcluster/pkg/syncer/vnode/vnode.go
+++ b/virtualcluster/pkg/syncer/vnode/vnode.go
@@ -141,12 +141,13 @@ func nodeConditions() []corev1.NodeCondition {
 }
 
 func UpdateNode(client v1core.NodeInterface, node, newNode *corev1.Node) error {
-	updatedNode, _, err := patchNodeStatus(client, types.NodeName(node.Name), node, newNode)
-	if err != nil {
-		return err
-	}
-	_, err = patchNode(client, types.NodeName(updatedNode.Name), updatedNode, newNode)
+	_, _, err := patchNodeStatus(client, types.NodeName(node.Name), node, newNode)
 	return err
+	// if err != nil {
+	// 	return err
+	// }
+	// _, err = patchNode(client, types.NodeName(updatedNode.Name), updatedNode, newNode)
+	// return err
 }
 
 func patchNode(nodes v1core.NodeInterface, nodeName types.NodeName, oldNode *corev1.Node, newNode *corev1.Node) (*corev1.Node, error) {

--- a/virtualcluster/pkg/syncer/vnode/vnode.go
+++ b/virtualcluster/pkg/syncer/vnode/vnode.go
@@ -155,9 +155,10 @@ func patchNode(nodes v1core.NodeInterface, nodeName types.NodeName, oldNode *cor
 		return nil, fmt.Errorf("failed to marshal old node %#v for node %q: %v", oldNode, nodeName, err)
 	}
 
+	// We can't override ResourceVersion and Generation, so we just update Spec and Labels only.
 	newNodeClone := oldNode.DeepCopy()
 	newNodeClone.Spec = newNode.Spec
-	newNodeClone.ObjectMeta = newNode.ObjectMeta
+	newNodeClone.ObjectMeta.SetLabels(newNode.ObjectMeta.Labels)
 
 	newData, err := json.Marshal(newNodeClone)
 	if err != nil {

--- a/virtualcluster/pkg/syncer/vnode/vnode.go
+++ b/virtualcluster/pkg/syncer/vnode/vnode.go
@@ -181,9 +181,9 @@ func patchNodeStatus(nodes v1core.NodeInterface, nodeName types.NodeName, oldNod
 		return nil, nil, err
 	}
 
-	updatedNode, err := nodes.Patch(context.TODO(), string(nodeName), types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
+	updatedNode, err := nodes.Patch(context.TODO(), string(nodeName), types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to patch status %q for node %q: %v", patchBytes, nodeName, err)
+		return nil, nil, fmt.Errorf("failed to patch %q for node %q: %v", patchBytes, nodeName, err)
 	}
 	return updatedNode, patchBytes, nil
 }

--- a/virtualcluster/pkg/util/cluster/cluster.go
+++ b/virtualcluster/pkg/util/cluster/cluster.go
@@ -122,18 +122,16 @@ func NewCluster(key, namespace, name, uid string, getter mccontroller.Getter, co
 	}
 
 	return &Cluster{
-		key:        key,
-		name:       name,
-		namespace:  namespace,
-		uid:        uid,
-		getter:     getter,
-		RestConfig: clusterRestConfig,
-		options:    o,
-		synced:     false,
-		context:    context.Background(),
-		cancelContext: func() {
-			klog.Errorf("Stop invoked before Start. This should not happen")
-		},
+		key:           key,
+		name:          name,
+		namespace:     namespace,
+		uid:           uid,
+		getter:        getter,
+		RestConfig:    clusterRestConfig,
+		options:       o,
+		synced:        false,
+		context:       context.Background(),
+		cancelContext: func() {},
 	}, nil
 }
 

--- a/virtualcluster/pkg/util/cluster/cluster.go
+++ b/virtualcluster/pkg/util/cluster/cluster.go
@@ -131,6 +131,9 @@ func NewCluster(key, namespace, name, uid string, getter mccontroller.Getter, co
 		options:    o,
 		synced:     false,
 		context:    context.Background(),
+		cancelContext: func() {
+			klog.Errorf("Stop invoked before Start. This should not happen")
+		},
 	}, nil
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The PR fixes two bugs found in syncer:
1. cancelFunc is not initialised in the cluster before runCluster method, which sometimes leads to nil-pointer panic when we want to remove virtualcluster with the broken control-plane. I initialize it to a noop func to avoid panic. (I found the same broken cluster, removed it and there are no panic in syncer then)
2. Node Patch for Status and Spec leads to conflicts as patch status implicitly updates ObjectMeta too (labels and ResourceVersion), and spec update then fails with "object is modified". The PR ensures Status patch is for Status only and the Spec + Label patch is for Spec and Labels only.
