### PR TITLE
✨Bypass vc-syncing if tenant has own scheduler and dedicated node.

### DIFF
--- a/virtualcluster/pkg/syncer/constants/constants.go
+++ b/virtualcluster/pkg/syncer/constants/constants.go
@@ -64,7 +64,7 @@ const (
 	// LabelSecretUID is the service account token secret UID in tenant namespace.
 	LabelSecretUID = "tenancy.x-k8s.io/secret.UID" // #nosec G101 -- This is a label key
 
-	// LabelTenantSchedulerName is used to by resources that do not need to be synced, but to be scheduled to a tenant controled node
+	// LabelTenantSchedulerName is used to by resources that do not need to be synced, but to be scheduled to a tenant controlled node
 	LabelTenantSchedulerName = "tenancy.x-k8s.io/tenant-scheduler"
 
 	// UwsControllerWorkerHigh is the quantity of the worker routine for a resource that generates high number of uws requests.

--- a/virtualcluster/pkg/syncer/constants/constants.go
+++ b/virtualcluster/pkg/syncer/constants/constants.go
@@ -64,6 +64,9 @@ const (
 	// LabelSecretUID is the service account token secret UID in tenant namespace.
 	LabelSecretUID = "tenancy.x-k8s.io/secret.UID" // #nosec G101 -- This is a label key
 
+	// LabelTenantSchedulerName is used to by resources that do not need to be synced, but to be scheduled to a tenant controled node
+	LabelTenantSchedulerName = "tenancy.x-k8s.io/tenant-scheduler"
+
 	// UwsControllerWorkerHigh is the quantity of the worker routine for a resource that generates high number of uws requests.
 	UwsControllerWorkerHigh = 10
 	// UwsControllerWorkerLow is the quantity of the worker routine for a resource that generates low number of uws requests.

--- a/virtualcluster/pkg/syncer/constants/constants.go
+++ b/virtualcluster/pkg/syncer/constants/constants.go
@@ -64,7 +64,7 @@ const (
 	// LabelSecretUID is the service account token secret UID in tenant namespace.
 	LabelSecretUID = "tenancy.x-k8s.io/secret.UID" // #nosec G101 -- This is a label key
 
-	// LabelTenantIgnoreSync is used by resources that do not need to be synced, but to be scheduled to a tenant controlled node
+	// LabelTenantIgnoreSync is used by resources that do not need to be synced.
 	LabelTenantIgnoreSync = "tenancy.x-k8s.io/ignore-sync"
 
 	// UwsControllerWorkerHigh is the quantity of the worker routine for a resource that generates high number of uws requests.

--- a/virtualcluster/pkg/syncer/constants/constants.go
+++ b/virtualcluster/pkg/syncer/constants/constants.go
@@ -64,8 +64,8 @@ const (
 	// LabelSecretUID is the service account token secret UID in tenant namespace.
 	LabelSecretUID = "tenancy.x-k8s.io/secret.UID" // #nosec G101 -- This is a label key
 
-	// LabelTenantSchedulerName is used to by resources that do not need to be synced, but to be scheduled to a tenant controlled node
-	LabelTenantSchedulerName = "tenancy.x-k8s.io/tenant-scheduler"
+	// LabelTenantIgnoreSync is used by resources that do not need to be synced, but to be scheduled to a tenant controlled node
+	LabelTenantIgnoreSync = "tenancy.x-k8s.io/ignore-sync"
 
 	// UwsControllerWorkerHigh is the quantity of the worker routine for a resource that generates high number of uws requests.
 	UwsControllerWorkerHigh = 10

--- a/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -160,7 +160,7 @@ func (c *controller) PatrollerDo() {
 	vSet := differ.NewDiffSet()
 
 	sel := labels.NewSelector()
-	if featuregate.DefaultFeatureGate.Enabled(featuregate.ResourceNoSync) {
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.TenantAllowResourceNoSync) {
 		r, err := labels.NewRequirement(constants.LabelTenantIgnoreSync, selection.NotEquals, []string{"true"})
 		if err == nil {
 			sel = sel.Add(*r)

--- a/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -170,6 +170,12 @@ func (c *controller) PatrollerDo() {
 					continue
 				}
 			}
+			// if LabelTenantSchedulerName is specified, bypass syncing
+			schedulerlabel, ok := vList.Items[i].GetLabels()[constants.LabelTenantSchedulerName]
+			if ok && schedulerlabel != "" {
+				klog.V(5).Infof("skip syncing pod with tenant scheduler label %v", schedulerlabel)
+				continue
+			}
 			vSet.Insert(differ.ClusterObject{
 				Object:       &vList.Items[i],
 				OwnerCluster: cluster,

--- a/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -25,10 +25,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/conversion"
@@ -155,9 +158,17 @@ func (c *controller) PatrollerDo() {
 
 	knownClusterSet := sets.NewString(clusterNames...)
 	vSet := differ.NewDiffSet()
+
+	sel := labels.NewSelector()
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.TenantScheduler) {
+		r, err := labels.NewRequirement(constants.LabelTenantSchedulerName, selection.DoesNotExist, nil)
+		if err == nil {
+			sel = sel.Add(*r)
+		}
+	}
 	for _, cluster := range clusterNames {
 		vList := &corev1.PodList{}
-		if err := c.MultiClusterController.List(cluster, vList); err != nil {
+		if err := c.MultiClusterController.List(cluster, vList, &client.MatchingLabelsSelector{Selector: sel}); err != nil {
 			klog.Errorf("error listing pod from cluster %s informer cache: %v", cluster, err)
 			knownClusterSet.Delete(cluster)
 			continue
@@ -170,12 +181,7 @@ func (c *controller) PatrollerDo() {
 					continue
 				}
 			}
-			// if LabelTenantSchedulerName is specified, bypass syncing
-			schedulerlabel, ok := vList.Items[i].GetLabels()[constants.LabelTenantSchedulerName]
-			if ok && schedulerlabel != "" {
-				klog.V(5).Infof("skip syncing pod with tenant scheduler label %v", schedulerlabel)
-				continue
-			}
+
 			vSet.Insert(differ.ClusterObject{
 				Object:       &vList.Items[i],
 				OwnerCluster: cluster,

--- a/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -161,7 +161,7 @@ func (c *controller) PatrollerDo() {
 
 	sel := labels.NewSelector()
 	if featuregate.DefaultFeatureGate.Enabled(featuregate.TenantScheduler) {
-		r, err := labels.NewRequirement(constants.LabelTenantSchedulerName, selection.DoesNotExist, nil)
+		r, err := labels.NewRequirement(constants.LabelTenantIgnoreSync, selection.NotEquals, []string{"true"})
 		if err == nil {
 			sel = sel.Add(*r)
 		}

--- a/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -160,7 +160,7 @@ func (c *controller) PatrollerDo() {
 	vSet := differ.NewDiffSet()
 
 	sel := labels.NewSelector()
-	if featuregate.DefaultFeatureGate.Enabled(featuregate.TenantScheduler) {
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.ResourceNoSync) {
 		r, err := labels.NewRequirement(constants.LabelTenantIgnoreSync, selection.NotEquals, []string{"true"})
 		if err == nil {
 			sel = sel.Add(*r)

--- a/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -60,9 +60,9 @@ func (c *controller) Reconcile(request reconciler.Request) (res reconciler.Resul
 		return reconciler.Result{Requeue: true}, err
 	}
 	if featuregate.DefaultFeatureGate.Enabled(featuregate.TenantScheduler) {
-		// if LabelTenantSchedulerName is specified, bypass syncing
-		schedulerlabel, ok := vPod.GetLabels()[constants.LabelTenantSchedulerName]
-		if ok && schedulerlabel != "" {
+		// if constants.LabelTenantIgnoreSync is true, bypass syncing
+		schedulerlabel, ok := vPod.GetLabels()[constants.LabelTenantIgnoreSync]
+		if ok && schedulerlabel == "true" {
 			klog.V(5).Infof("skip syncing pod with tenant scheduler label")
 			return reconciler.Result{}, nil
 		}

--- a/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -55,11 +55,6 @@ func (c *controller) Reconcile(request reconciler.Request) (res reconciler.Resul
 	reconcilestart := time.Now()
 	targetNamespace := conversion.ToSuperClusterNamespace(request.ClusterName, request.Namespace)
 
-	pPod, err := c.podLister.Pods(targetNamespace).Get(request.Name)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return reconciler.Result{Requeue: true}, err
-	}
-
 	vPod := &corev1.Pod{}
 	if err := c.MultiClusterController.Get(request.ClusterName, request.Namespace, request.Name, vPod); err != nil && !apierrors.IsNotFound(err) {
 		return reconciler.Result{Requeue: true}, err
@@ -71,6 +66,10 @@ func (c *controller) Reconcile(request reconciler.Request) (res reconciler.Resul
 			klog.V(5).Infof("skip syncing pod with tenant scheduler label")
 			return reconciler.Result{}, nil
 		}
+	}
+	pPod, err := c.podLister.Pods(targetNamespace).Get(request.Name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return reconciler.Result{Requeue: true}, err
 	}
 
 	var operation string

--- a/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -64,6 +64,12 @@ func (c *controller) Reconcile(request reconciler.Request) (res reconciler.Resul
 	if err := c.MultiClusterController.Get(request.ClusterName, request.Namespace, request.Name, vPod); err != nil && !apierrors.IsNotFound(err) {
 		return reconciler.Result{Requeue: true}, err
 	}
+	// if LabelTenantSchedulerName is specified, bypass syncing
+	schedulerlabel, ok := vPod.GetLabels()[constants.LabelTenantSchedulerName]
+	if ok && schedulerlabel != "" {
+		klog.V(5).Infof("skip syncing pod with tenant scheduler label")
+		return reconciler.Result{}, nil
+	}
 
 	var operation string
 	defer func() {

--- a/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -64,11 +64,13 @@ func (c *controller) Reconcile(request reconciler.Request) (res reconciler.Resul
 	if err := c.MultiClusterController.Get(request.ClusterName, request.Namespace, request.Name, vPod); err != nil && !apierrors.IsNotFound(err) {
 		return reconciler.Result{Requeue: true}, err
 	}
-	// if LabelTenantSchedulerName is specified, bypass syncing
-	schedulerlabel, ok := vPod.GetLabels()[constants.LabelTenantSchedulerName]
-	if ok && schedulerlabel != "" {
-		klog.V(5).Infof("skip syncing pod with tenant scheduler label")
-		return reconciler.Result{}, nil
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.TenantScheduler) {
+		// if LabelTenantSchedulerName is specified, bypass syncing
+		schedulerlabel, ok := vPod.GetLabels()[constants.LabelTenantSchedulerName]
+		if ok && schedulerlabel != "" {
+			klog.V(5).Infof("skip syncing pod with tenant scheduler label")
+			return reconciler.Result{}, nil
+		}
 	}
 
 	var operation string

--- a/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -59,7 +59,7 @@ func (c *controller) Reconcile(request reconciler.Request) (res reconciler.Resul
 	if err := c.MultiClusterController.Get(request.ClusterName, request.Namespace, request.Name, vPod); err != nil && !apierrors.IsNotFound(err) {
 		return reconciler.Result{Requeue: true}, err
 	}
-	if featuregate.DefaultFeatureGate.Enabled(featuregate.ResourceNoSync) {
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.TenantAllowResourceNoSync) {
 		// if constants.LabelTenantIgnoreSync is true, bypass syncing
 		ignoresynclabel, ok := vPod.GetLabels()[constants.LabelTenantIgnoreSync]
 		if ok && ignoresynclabel == "true" {

--- a/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -59,11 +59,11 @@ func (c *controller) Reconcile(request reconciler.Request) (res reconciler.Resul
 	if err := c.MultiClusterController.Get(request.ClusterName, request.Namespace, request.Name, vPod); err != nil && !apierrors.IsNotFound(err) {
 		return reconciler.Result{Requeue: true}, err
 	}
-	if featuregate.DefaultFeatureGate.Enabled(featuregate.TenantScheduler) {
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.ResourceNoSync) {
 		// if constants.LabelTenantIgnoreSync is true, bypass syncing
-		schedulerlabel, ok := vPod.GetLabels()[constants.LabelTenantIgnoreSync]
-		if ok && schedulerlabel == "true" {
-			klog.V(5).Infof("skip syncing pod with tenant scheduler label")
+		ignoresynclabel, ok := vPod.GetLabels()[constants.LabelTenantIgnoreSync]
+		if ok && ignoresynclabel == "true" {
+			klog.V(5).Infof("skip syncing pod with ignore sync label = %v", ignoresynclabel)
 			return reconciler.Result{}, nil
 		}
 	}

--- a/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -69,9 +69,9 @@ const (
 	// to apply ClusterVersion updates if VirtualCluster object is requested it
 	ClusterVersionPartialUpgrade = "ClusterVersionPartialUpgrade"
 
-	// TenantScheduler is an experimental feature that allows the tenant
-	// to have dedicated nodes and own scheduler instead of using vc-syncer
-	TenantScheduler = "TenantScheduler"
+	// ResourceNoSync is an experimental feature that gives tenant the capability
+	// of not syncing certain resources to super cluster.
+	ResourceNoSync = "ResourceNoSync"
 )
 
 var defaultFeatures = FeatureList{
@@ -83,7 +83,7 @@ var defaultFeatures = FeatureList{
 	TenantAllowDNSPolicy:         {Default: false},
 	VNodeProviderPodIP:           {Default: false},
 	ClusterVersionPartialUpgrade: {Default: false},
-	TenantScheduler:              {Default: false},
+	ResourceNoSync:               {Default: false},
 }
 
 type Feature string

--- a/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -69,9 +69,9 @@ const (
 	// to apply ClusterVersion updates if VirtualCluster object is requested it
 	ClusterVersionPartialUpgrade = "ClusterVersionPartialUpgrade"
 
-	// ResourceNoSync is an experimental feature that gives tenant the capability
+	// TenantAllowResourceNoSync is an experimental feature that gives tenant the capability
 	// of not syncing certain resources to super cluster.
-	ResourceNoSync = "ResourceNoSync"
+	TenantAllowResourceNoSync = "TenantAllowResourceNoSync"
 )
 
 var defaultFeatures = FeatureList{
@@ -83,7 +83,7 @@ var defaultFeatures = FeatureList{
 	TenantAllowDNSPolicy:         {Default: false},
 	VNodeProviderPodIP:           {Default: false},
 	ClusterVersionPartialUpgrade: {Default: false},
-	ResourceNoSync:               {Default: false},
+	TenantAllowResourceNoSync:    {Default: false},
 }
 
 type Feature string

--- a/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -68,6 +68,10 @@ const (
 	// ClusterVersionPartialUpgrade is an experimental feature that allows the cluster provisioner
 	// to apply ClusterVersion updates if VirtualCluster object is requested it
 	ClusterVersionPartialUpgrade = "ClusterVersionPartialUpgrade"
+
+	// TenantScheduler is an experimental feature that allows the tenant
+	// to have dedicated nodes and own scheduler instead of using vc-syncer
+	TenantScheduler = "TenantScheduler"
 )
 
 var defaultFeatures = FeatureList{
@@ -79,6 +83,7 @@ var defaultFeatures = FeatureList{
 	TenantAllowDNSPolicy:         {Default: false},
 	VNodeProviderPodIP:           {Default: false},
 	ClusterVersionPartialUpgrade: {Default: false},
+	TenantScheduler:              {Default: false},
 }
 
 type Feature string


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
For certain tenants, they may be assigned with dedicated nodes and can schedule workload (pod) to these nodes with tenant scheduler. We would like to introduce a new label: "tenancy.x-k8s.io/tenant-scheduler" to let vc-syncer to be aware of the situation and skip the syncing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # N/A
