### PR TITLE
🐛 Handle deprecated preserveUnknownField in CRD spec

### DIFF
--- a/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/virtualcluster/pkg/syncer/conversion/helper.go
@@ -306,6 +306,14 @@ func BuildVirtualPriorityClass(cluster string, pPriorityClass *v1scheduling.Prio
 func BuildVirtualCRD(cluster string, pCRD *apiextensionsv1.CustomResourceDefinition) *apiextensionsv1.CustomResourceDefinition {
 	vCRD := pCRD.DeepCopy()
 	ResetMetadata(vCRD)
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.DisableCRDPreserveUnknownFields) {
+		// In Kubernetes 1.20 the spec.preserveUnknownFields is not allowed to be set to true
+		// given Kubernetes has already deprecated this any cluster >=1.20 will not be able
+		// sync these resources, instead if a CRD has the field still set this disables that.
+		vCRD.Spec.PreserveUnknownFields = false
+
+	}
+
 	return vCRD
 }
 

--- a/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -72,18 +72,23 @@ const (
 	// TenantAllowResourceNoSync is an experimental feature that gives tenant the capability
 	// of not syncing certain resources to super cluster.
 	TenantAllowResourceNoSync = "TenantAllowResourceNoSync"
+
+	// DisableCRDPreserveUnknownFields helps control syncing deprecated(k8s <= 1.20) field on CRD.
+	// Enabling this will set spec.preserveUnknownField to false regardless the value in source CRD spec.
+	DisableCRDPreserveUnknownFields = "DisableCRDPreserveUnknownFields"
 )
 
 var defaultFeatures = FeatureList{
-	SuperClusterPooling:          {Default: false},
-	SuperClusterServiceNetwork:   {Default: false},
-	SuperClusterLabelling:        {Default: false},
-	SuperClusterLabelFilter:      {Default: false},
-	VNodeProviderService:         {Default: false},
-	TenantAllowDNSPolicy:         {Default: false},
-	VNodeProviderPodIP:           {Default: false},
-	ClusterVersionPartialUpgrade: {Default: false},
-	TenantAllowResourceNoSync:    {Default: false},
+	SuperClusterPooling:             {Default: false},
+	SuperClusterServiceNetwork:      {Default: false},
+	SuperClusterLabelling:           {Default: false},
+	SuperClusterLabelFilter:         {Default: false},
+	VNodeProviderService:            {Default: false},
+	TenantAllowDNSPolicy:            {Default: false},
+	VNodeProviderPodIP:              {Default: false},
+	ClusterVersionPartialUpgrade:    {Default: false},
+	TenantAllowResourceNoSync:       {Default: false},
+	DisableCRDPreserveUnknownFields: {Default: false},
 }
 
 type Feature string


### PR DESCRIPTION

<!-- the icon will be either ⚠️  🐛 (:bug:, patch and bugfixes), -->

**What this PR does / why we need it**:
In Kubernetes 1.20 the spec.preserveUnknownFields is not allowed to be set to true given Kubernetes has already deprecated this any cluster >=1.20 will not be able sync these resources, instead if a CRD has the field still set this disables that.

