### PR TITLE
✨ Add PersistentVolumeClaim status UWS

### DIFF
--- a/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/virtualcluster/pkg/syncer/conversion/equality.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/virtualcluster/pkg/syncer/conversion/equality.go
@@ -720,6 +720,20 @@ func (e vcEquality) CheckPVCEquality(pObj, vObj *v1.PersistentVolumeClaim) *v1.P
 	return updated
 }
 
+func (e vcEquality) CheckUWPVCStatusEquality(pObj, vObj *v1.PersistentVolumeClaim) *v1.PersistentVolumeClaim {
+	var updated *v1.PersistentVolumeClaim
+	if pObj.Status.Capacity != nil && pObj.Status.Capacity["storage"] != vObj.Status.Capacity["storage"] {
+		if updated == nil {
+			updated = vObj.DeepCopy()
+		}
+		if updated.Status.Capacity == nil {
+			updated.Status.Capacity = make(map[v1.ResourceName]resource.Quantity)
+		}
+		updated.Status.Capacity["storage"] = pObj.Status.Capacity["storage"]
+	}
+	return updated
+}
+
 func (e vcEquality) CheckPVSpecEquality(pObj, vObj *v1.PersistentVolumeSpec) *v1.PersistentVolumeSpec {
 	var updatedPVSpec *v1.PersistentVolumeSpec
 	pCopy := pObj.DeepCopy()

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/checker.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/checker.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -110,6 +110,11 @@ func (c *controller) PatrollerDo() {
 		if updatedPVC != nil {
 			atomic.AddUint64(&numMissMatchedPVCs, 1)
 			klog.Warningf("spec of pvc %s diff in super&tenant control plane", pObj.Key)
+		}
+
+		if conversion.Equality(c.Config, vc).CheckUWPVCStatusEquality(p, v) != nil {
+			klog.Warningf("status of pvc %v/%v diff in super&tenant control plane", p.Namespace, p.Name)
+			c.enqueuePersistentVolumeClaim(p)
 		}
 	}
 	d.DeleteFunc = func(pObj differ.ClusterObject) {

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/controller.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/controller.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/controller.go
@@ -18,6 +18,7 @@ package persistentvolumeclaim
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/informers"

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/controller.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/controller.go
@@ -17,18 +17,24 @@ limitations under the License.
 package persistentvolumeclaim
 
 import (
+	"fmt"
 	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/conversion"
 
 	vcclient "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/client/clientset/versioned"
 	vcinformers "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/client/informers/externalversions/tenancy/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/apis/config"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/manager"
 	pa "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/patrol"
+	uw "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/uwcontroller"
 	mc "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/mccontroller"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/plugin"
 )
@@ -49,6 +55,7 @@ type controller struct {
 	// super control plane pvc lister
 	pvcLister listersv1.PersistentVolumeClaimLister
 	pvcSynced cache.InformerSynced
+	informer  coreinformers.Interface
 }
 
 func NewPVCController(config *config.SyncerConfiguration,
@@ -62,6 +69,7 @@ func NewPVCController(config *config.SyncerConfiguration,
 			Config: config,
 		},
 		pvcClient: client.CoreV1(),
+		informer:  informer.Core().V1(),
 	}
 
 	var err error
@@ -77,10 +85,44 @@ func NewPVCController(config *config.SyncerConfiguration,
 		c.pvcSynced = informer.Core().V1().PersistentVolumeClaims().Informer().HasSynced
 	}
 
+	c.UpwardController, err = uw.NewUWController(&corev1.PersistentVolumeClaim{}, c, uw.WithOptions(options.UWOptions))
+	if err != nil {
+		return nil, err
+	}
+
 	c.Patroller, err = pa.NewPatroller(&corev1.PersistentVolumeClaim{}, c, pa.WithOptions(options.PatrolOptions))
 	if err != nil {
 		return nil, err
 	}
 
+	c.informer.PersistentVolumeClaims().Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				pvc := newObj.(*corev1.PersistentVolumeClaim)
+				c.enqueuePersistentVolumeClaim(pvc)
+			},
+		},
+	)
 	return c, nil
+}
+
+func (c *controller) enqueuePersistentVolumeClaim(obj interface{}) {
+	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return
+	}
+
+	clusterName, _ := conversion.GetVirtualOwner(pvc)
+	if clusterName == "" {
+		return
+	}
+
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %v: %v", obj, err))
+		return
+	}
+
+	klog.V(4).Infof("enqueue PersistentVolumeClaim %s", key)
+	c.UpwardController.AddToQueue(key)
 }

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/controller.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/controller.go
@@ -28,13 +28,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/conversion"
+	uw "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/uwcontroller"
 
 	vcclient "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/client/clientset/versioned"
 	vcinformers "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/client/informers/externalversions/tenancy/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/apis/config"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/manager"
 	pa "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/patrol"
-	uw "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/uwcontroller"
 	mc "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/mccontroller"
 	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/plugin"
 )

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws.go
@@ -19,6 +19,7 @@ package persistentvolumeclaim
 import (
 	"context"
 	"fmt"
+
 	pkgerr "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolumeclaim
+
+import (
+	"context"
+	"fmt"
+	pkgerr "github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/conversion"
+)
+
+// StartUWS starts the upward syncer
+// and blocks until an empty struct is sent to the stop channel.
+func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	if !cache.WaitForCacheSync(stopCh, c.pvcSynced, c.pvcSynced) {
+		return fmt.Errorf("failed to wait for caches to sync persistentvolumeclaim")
+	}
+	return c.UpwardController.Start(stopCh)
+}
+
+func (c *controller) BackPopulate(key string) error {
+	pNamespace, pName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("invalid resource key %v: %v", key, err))
+		return nil
+	}
+
+	pPVC, err := c.pvcLister.PersistentVolumeClaims(pNamespace).Get(pName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	clusterName, vNamespace := conversion.GetVirtualOwner(pPVC)
+	if clusterName == "" {
+		// Bound PVC does not belong to any tenant.
+		return nil
+	}
+
+	tenantClient, err := c.MultiClusterController.GetClusterClient(clusterName)
+	if err != nil {
+		return pkgerr.Wrapf(err, "failed to create client from cluster %s config", clusterName)
+	}
+
+	vPVC := &corev1.PersistentVolumeClaim{}
+	if err := c.MultiClusterController.Get(clusterName, vNamespace, pName, vPVC); err != nil {
+		klog.Errorf("failed to get tenant cluster %s pvc %s/%s", clusterName, vNamespace, pName)
+		return err
+	}
+
+	updatedPVC := conversion.Equality(c.Config, nil).CheckUWPVCStatusEquality(pPVC, vPVC)
+	if updatedPVC != nil {
+		_, err = tenantClient.CoreV1().PersistentVolumeClaims(vNamespace).UpdateStatus(context.TODO(), updatedPVC, metav1.UpdateOptions{})
+		if err != nil {
+			klog.Errorf("failed to update tenant cluster %s pvc %s/%s, %v", clusterName, vNamespace, pName, err)
+			return err
+		}
+	}
+	return nil
+}

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	pkgerr "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,7 +61,7 @@ func (c *controller) BackPopulate(key string) error {
 
 	tenantClient, err := c.MultiClusterController.GetClusterClient(clusterName)
 	if err != nil {
-		return pkgerr.Wrapf(err, "failed to create client from cluster %s config", clusterName)
+		return fmt.Errorf("failed to create client from cluster %s config: %w", clusterName, err)
 	}
 
 	vPVC := &corev1.PersistentVolumeClaim{}

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws_test.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws_test.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolumeclaim
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	core "k8s.io/client-go/testing"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/conversion"
+	util "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/util/test"
+)
+
+func updatePVCStatus(pvc *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
+	if pvc.Status.Capacity == nil {
+		pvc.Status.Capacity = make(map[corev1.ResourceName]resource.Quantity)
+	}
+	pvc.Status.Capacity["storage"] = *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI)
+	return pvc
+}
+
+func TestUWPVCUpdate(t *testing.T) {
+	testTenant := &v1alpha1.VirtualCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "tenant-1",
+			UID:       "7374a172-c35d-45b1-9c8e-bf5c5b614937",
+		},
+		Status: v1alpha1.VirtualClusterStatus{
+			Phase: v1alpha1.ClusterRunning,
+		},
+	}
+
+	defaultClusterKey := conversion.ToClusterKey(testTenant)
+	superDefaultNSName := conversion.ToSuperClusterNamespace(defaultClusterKey, "default")
+
+	testcases := map[string]struct {
+		ExistingObjectInSuper  []runtime.Object
+		ExistingObjectInTenant []runtime.Object
+		EnqueuedKey            string
+		ExpectedUpdatedObject  []string
+		ExpectedError          string
+	}{
+		"pPVC exists, vPVC exists with no diff": {
+			ExistingObjectInSuper: []runtime.Object{
+				tenantPVC("pvc-1", "default", "12345"),
+			},
+			ExistingObjectInTenant: []runtime.Object{
+				tenantPVC("pvc-1", "default", "12345"),
+			},
+			EnqueuedKey:   superDefaultNSName + "/pvc-1",
+			ExpectedError: "",
+		},
+		"pPVC exists, but vPVC does not exist": {
+			ExistingObjectInSuper: []runtime.Object{
+				tenantPVC("pvc-1", "default", "12345"),
+			},
+			ExistingObjectInTenant: []runtime.Object{},
+			EnqueuedKey:            superDefaultNSName + "/pvc-1",
+			ExpectedError:          "",
+		},
+		"vPVC exists, but pPVC does not exist": {
+			ExistingObjectInSuper: []runtime.Object{},
+			ExistingObjectInTenant: []runtime.Object{
+				tenantPVC("pvc-1", "default", "12345"),
+			},
+			EnqueuedKey:   superDefaultNSName + "/pvc-1",
+			ExpectedError: "",
+		},
+		"pPVC exists, vPVC exists with different status": {
+			ExistingObjectInSuper: []runtime.Object{
+				updatePVCStatus(superPVC("pvc-1", superDefaultNSName, "12345", defaultClusterKey)),
+			},
+			ExistingObjectInTenant: []runtime.Object{
+				tenantPVC("pvc-1", "default", "12345"),
+			},
+			EnqueuedKey: superDefaultNSName + "/pvc-1",
+			ExpectedUpdatedObject: []string{
+				"default/pvc-1",
+			},
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			actions, reconcileErr, err := util.RunUpwardSync(NewPVCController, testTenant, tc.ExistingObjectInSuper, tc.ExistingObjectInTenant, tc.EnqueuedKey, nil)
+			if err != nil {
+				t.Errorf("%s: error running upward sync: %v", k, err)
+				return
+			}
+
+			if reconcileErr != nil {
+				if tc.ExpectedError == "" {
+					t.Errorf("expected no error, but got \"%v\"", reconcileErr)
+				} else if !strings.Contains(reconcileErr.Error(), tc.ExpectedError) {
+					t.Errorf("expected error msg \"%s\", but got \"%v\"", tc.ExpectedError, reconcileErr)
+				}
+			} else {
+				if tc.ExpectedError != "" {
+					t.Errorf("expected error msg \"%s\", but got empty", tc.ExpectedError)
+				}
+			}
+
+			for _, expectedName := range tc.ExpectedUpdatedObject {
+				matched := false
+				for _, action := range actions {
+					if !action.Matches("update", "persistentvolumeclaims") {
+						continue
+					}
+					actionObj := action.(core.UpdateAction).GetObject()
+					accessor, _ := meta.Accessor(actionObj)
+					fullName := accessor.GetNamespace() + "/" + accessor.GetName()
+					if fullName != expectedName {
+						t.Errorf("%s: Expected pvc %s to be updated, got %s", k, expectedName, fullName)
+					}
+					matched = true
+					break
+				}
+				if !matched {
+					t.Errorf("%s: Expect updated pvc %s but not found", k, expectedName)
+				}
+			}
+		})
+	}
+}

--- a/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws_test.go
+++ b/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/uws_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package persistentvolumeclaim
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	core "k8s.io/client-go/testing"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add PersistentVolumeClaim status upward sync. When we resize the storage of vPVC in VC, the CSI driver on the super cluster would update the pPVC.status.capacity after capacity expansion. Then we need to update vPVC status synchronously. 

This time, we only consider the capacity update, and other information (such as accessModes and phase) will not be synchronized.

**Which issue(s) this PR fixes**:

Relate: #322

/kind feature