### PR TITLE
🐛 Fix syncer panic when vc lister occur error

### DIFF
--- a/virtualcluster/pkg/util/cluster/cluster.go
+++ b/virtualcluster/pkg/util/cluster/cluster.go
@@ -325,5 +325,8 @@ func (c *Cluster) SetKey(k string) {
 
 // Stop cancel/close the cache to terminate informers.
 func (c *Cluster) Stop() {
+	if c.cancelContext == nil {
+		return
+	}
 	c.cancelContext()
 }


### PR DESCRIPTION
As a developer, I got the syncer panic today. The output look something like this:

```bash
E1013 03:34:17.540825       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 566 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x197d200, 0x2dc1670})
        /workspace/source/src/sigs.k8s.io/cluster-api-provider-nested/virtualcluster/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc01eff6590})
        /workspace/source/src/sigs.k8s.io/cluster-api-provider-nested/virtualcluster/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x75
panic({0x197d200, 0x2dc1670})
        /usr/local/go/src/runtime/panic.go:1038 +0x215
sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/cluster.(*Cluster).Stop(0x1960880)
        /workspace/source/src/sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/cluster/cluster.go:362 +0x19
sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer.(*Syncer).removeCluster(0xc00070db00, {0xc01e6d2be8, 0x13})
        /workspace/source/src/sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/syncer.go:337 +0x1d4
sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer.(*Syncer).syncVirtualCluster(0xc00070db00, {0xc01e6d2be8, 0x13})
        /workspace/source/src/sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/syncer.go:308 +0x225
sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer.(*Syncer).processNextWorkItem(0xc00070db00)
        /workspace/source/src/sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/syncer.go:284 +0xf6
sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer.(*Syncer).run(...)
        /workspace/source/src/sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/syncer.go:273
```

https://github.com/kubernetes-sigs/cluster-api-provider-nested/blob/main/virtualcluster/pkg/syncer/syncer.go#L305
```go
func (s *Syncer) syncVirtualCluster(key string) error {
        // snip
        vc, err := s.lister.VirtualClusters(namespace).Get(name)
        if err != nil {
                if !apierrors.IsNotFound(err) {
                        return err
                }

                // panic here! removeCluster->vc.Stop(), when get the vc not ready.
                s.removeCluster(key)
                return nil
        }

        switch vc.Status.Phase {
        case v1alpha1.ClusterRunning:
                return s.addCluster(key, vc)
        case v1alpha1.ClusterError:
                s.removeCluster(key)
                return nil
        default:
                klog.Infof("Cluster %s/%s not ready to reconcile", vc.Namespace, vc.Name)
                return nil
        }
}
```

What type of PR is this?
/kind bug
