### PR TITLE
🐛 v1.21 Support for RootCACertConfigMap feature

### DIFF
--- a/virtualcluster/pkg/syncer/constants/constants.go
+++ b/virtualcluster/pkg/syncer/constants/constants.go
@@ -100,6 +100,14 @@ const (
 	LabelSuperClusterIP = "transparency.tenancy.x-k8s.io/clusterIP"
 
 	KubeconfigAdminSecretName = "admin-kubeconfig" // #nosec G101 -- This is a secret name
+
+	// RootCACertConfigMapName is name of the configmap which stores certificates
+	// to access api-server
+	RootCACertConfigMapName = "kube-root-ca.crt"
+
+	// TenantRootCACertConfigMapName is name of the configmap which stores certificates
+	// to access api-server
+	TenantRootCACertConfigMapName = "tenant-kube-root-ca.crt"
 )
 
 const (

--- a/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/virtualcluster/pkg/syncer/conversion/helper.go
@@ -114,6 +114,14 @@ func GetKubeConfigOfVC(c v1core.CoreV1Interface, vc *v1alpha1.VirtualCluster) ([
 	return adminKubeConfigSecret.Data[secretFieldName], nil
 }
 
+func GetConfigMapName(name string) (string, string) {
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.RootCACertConfigMapSupport) &&
+		name == constants.RootCACertConfigMapName {
+		return name, constants.TenantRootCACertConfigMapName
+	}
+	return name, name
+}
+
 type objectConversion struct {
 	config *config.SyncerConfiguration
 	mcc    mc.MultiClusterInterface

--- a/virtualcluster/pkg/syncer/resources/pod/mutatorplugin/podrootcacertmutator.go
+++ b/virtualcluster/pkg/syncer/resources/pod/mutatorplugin/podrootcacertmutator.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutatorplugin
+
+import (
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/conversion"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/util/featuregate"
+	uplugin "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/util/plugin"
+)
+
+func init() {
+	MutatorRegister.Register(&uplugin.Registration{
+		ID: "00_PodRootCACertMutator",
+		InitFn: func(ctx *uplugin.InitContext) (interface{}, error) {
+			return &PodRootCACertMutatorPlugin{}, nil
+		},
+	})
+}
+
+type PodRootCACertMutatorPlugin struct{}
+
+// Mutator will automatically reassign configmap references for configmaps named
+// kube-root-ca.crt in the pod spec, these places are
+// * volumes
+// * env
+// * envFrom
+func (pl *PodRootCACertMutatorPlugin) Mutator() conversion.PodMutator {
+	return func(p *conversion.PodMutateCtx) error {
+		if !featuregate.DefaultFeatureGate.Enabled(featuregate.RootCACertConfigMapSupport) {
+			return nil
+		}
+
+		for i := range p.PPod.Spec.Volumes {
+			if p.PPod.Spec.Volumes[i].ConfigMap != nil && p.PPod.Spec.Volumes[i].ConfigMap.Name == constants.RootCACertConfigMapName {
+				p.PPod.Spec.Volumes[i].ConfigMap.Name = constants.TenantRootCACertConfigMapName
+			}
+		}
+
+		for c := range p.PPod.Spec.Containers {
+			for e := range p.PPod.Spec.Containers[c].Env {
+				if p.PPod.Spec.Containers[c].Env[e].ValueFrom != nil &&
+					p.PPod.Spec.Containers[c].Env[e].ValueFrom.ConfigMapKeyRef != nil &&
+					p.PPod.Spec.Containers[c].Env[e].ValueFrom.ConfigMapKeyRef.Name == constants.RootCACertConfigMapName {
+					p.PPod.Spec.Containers[c].Env[e].ValueFrom.ConfigMapKeyRef.Name = constants.TenantRootCACertConfigMapName
+				}
+			}
+
+			for e := range p.PPod.Spec.Containers[c].EnvFrom {
+				if p.PPod.Spec.Containers[c].EnvFrom[e].ConfigMapRef != nil &&
+					p.PPod.Spec.Containers[c].EnvFrom[e].ConfigMapRef.Name == constants.RootCACertConfigMapName {
+					p.PPod.Spec.Containers[c].EnvFrom[e].ConfigMapRef.Name = constants.TenantRootCACertConfigMapName
+				}
+			}
+		}
+		return nil
+	}
+}

--- a/virtualcluster/pkg/syncer/resources/pod/mutatorplugin/podrootcacertmutator_test.go
+++ b/virtualcluster/pkg/syncer/resources/pod/mutatorplugin/podrootcacertmutator_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutatorplugin
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/constants"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/conversion"
+	"sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/util/featuregate"
+	util "sigs.k8s.io/cluster-api-provider-nested/virtualcluster/pkg/syncer/util/test"
+)
+
+func tenantPod(name, namespace, uid string, fns ...func(*corev1.Pod)) *corev1.Pod {
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       types.UID(uid),
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "default",
+			Containers: []corev1.Container{
+				{
+					Image: "busybox",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "root-ca-cert",
+							MountPath: "/path",
+						},
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name: "root-ca-crt-env",
+							ValueFrom: &corev1.EnvVarSource{
+								ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: constants.RootCACertConfigMapName},
+									Key:                  "ca.crt",
+								},
+							},
+						},
+					},
+					EnvFrom: []corev1.EnvFromSource{
+						{
+							ConfigMapRef: &corev1.ConfigMapEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: constants.RootCACertConfigMapName},
+							},
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "root-ca-cert",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: constants.RootCACertConfigMapName},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, fn := range fns {
+		fn(p)
+	}
+
+	return p
+}
+
+func TestPodRootCACertMutatorPlugin_Mutator(t *testing.T) {
+	defer util.SetFeatureGateDuringTest(t, featuregate.DefaultFeatureGate, featuregate.RootCACertConfigMapSupport, true)()
+
+	tests := []struct {
+		name string
+		pPod *corev1.Pod
+	}{
+		{
+			"Test RootCACert Mutator",
+			tenantPod("test", "default", "123-456-789"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pl := &PodRootCACertMutatorPlugin{}
+			mutator := pl.Mutator()
+
+			if err := mutator(&conversion.PodMutateCtx{PPod: tt.pPod}); err != nil {
+				t.Errorf("mutator failed processing the pod")
+			}
+
+			for i := range tt.pPod.Spec.Volumes {
+				if tt.pPod.Spec.Volumes[i].ConfigMap.Name != constants.TenantRootCACertConfigMapName {
+					t.Errorf("tt.pPod.Spec.Volumes[i].ConfigMap.Name = %v, want %v", tt.pPod.Spec.Volumes[i].ConfigMap.Name, constants.TenantRootCACertConfigMapName)
+				}
+			}
+
+			for c := range tt.pPod.Spec.Containers {
+				for e := range tt.pPod.Spec.Containers[c].Env {
+					if tt.pPod.Spec.Containers[c].Env[e].ValueFrom.ConfigMapKeyRef.Name != constants.TenantRootCACertConfigMapName {
+						t.Errorf("tt.pPod.Spec.Containers[c].Env[e].ValueFrom.ConfigMapKeyRef.Name = %v, want %v", tt.pPod.Spec.Containers[c].Env[e].ValueFrom.ConfigMapKeyRef.Name, constants.TenantRootCACertConfigMapName)
+					}
+				}
+				for e := range tt.pPod.Spec.Containers[c].EnvFrom {
+					if tt.pPod.Spec.Containers[c].EnvFrom[e].ConfigMapRef.Name != constants.TenantRootCACertConfigMapName {
+						t.Errorf("tt.pPod.Spec.Containers[c].EnvFrom[e].ConfigMapRef.Name = %v, want %v", tt.pPod.Spec.Containers[c].EnvFrom[e].ConfigMapRef.Name, constants.TenantRootCACertConfigMapName)
+					}
+				}
+			}
+		})
+	}
+}

--- a/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -76,6 +76,10 @@ const (
 	// DisableCRDPreserveUnknownFields helps control syncing deprecated(k8s <= 1.20) field on CRD.
 	// Enabling this will set spec.preserveUnknownField to false regardless the value in source CRD spec.
 	DisableCRDPreserveUnknownFields = "DisableCRDPreserveUnknownFields"
+
+	// RootCACertConfigMapSupport is an experimental feature that allows clusters +1.21 to support
+	// the kube-root-ca.crt dropped into each Namespace
+	RootCACertConfigMapSupport = "RootCACertConfigMapSupport"
 )
 
 var defaultFeatures = FeatureList{
@@ -89,6 +93,7 @@ var defaultFeatures = FeatureList{
 	ClusterVersionPartialUpgrade:    {Default: false},
 	TenantAllowResourceNoSync:       {Default: false},
 	DisableCRDPreserveUnknownFields: {Default: false},
+	RootCACertConfigMapSupport:      {Default: false},
 }
 
 type Feature string


### PR DESCRIPTION


<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds feature gated support for VirtualCluster to work with any Kubernetes version +1.21 and when the `RootCACertConfigMap` feature is enabled in 1.20 clusters. To implement this rather than fighting the super cluster for the `kube-root-ca.crt` we will create a prefixed ConfigMap in each namespace `tenant-kube-root-ca.crt` and then when pods are synced we have an additional mutator that will rewrite the ConfigMap to the proper resource. This allows both super and tenant to work and requires no changes from a tenants workloads.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #293

Signed-off-by: Chris Hein <me@chrishein.com>