### PR TITLE
🌱 volume.Projected support for kube-root-ca.crt ConfigMaps

### DIFF
--- a/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/virtualcluster/pkg/syncer/conversion/equality.go
@@ -477,13 +477,6 @@ func (e vcEquality) CheckConfigMapEquality(pObj, vObj *v1.ConfigMap) *v1.ConfigM
 		updated.BinaryData = updateBinaryData
 	}
 
-	// After we have processed the equality checks if updated is not nil reupdate to include
-	// super's ConfigMap Name
-	if featuregate.DefaultFeatureGate.Enabled(featuregate.RootCACertConfigMapSupport) &&
-		vObj.Name == constants.RootCACertConfigMapName && updated != nil {
-		updated.Name = constants.TenantRootCACertConfigMapName
-	}
-
 	return updated
 }
 

--- a/virtualcluster/pkg/syncer/resources/configmap/checker_test.go
+++ b/virtualcluster/pkg/syncer/resources/configmap/checker_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -93,7 +93,9 @@ func TestConfigMapPatrol(t *testing.T) {
 			ExistingObjectInSuper: []runtime.Object{
 				superConfigMap(constants.TenantRootCACertConfigMapName, superDefaultNSName, "12345", defaultClusterKey),
 			},
-			ExpectedNoOperation: true,
+			ExpectedDeletedPObject: []string{
+				superDefaultNSName + "/" + constants.TenantRootCACertConfigMapName,
+			},
 		},
 		"pConfigMap exists, vConfigMap exists with different uid": {
 			ExistingObjectInSuper: []runtime.Object{


### PR DESCRIPTION
**What this PR does / why we need it** :
In this PR I would like to make volume.Projected support for kube-root-ca.crt ConfigMaps. And meanwhile renew the Checker to check  the TenantRootCACertConfigMapName in super.

**Which issue(s) this PR fixes** :
Fixes #

/kind feature