### PR TITLE
🌱 Update feature-gate util

### DIFF
--- a/virtualcluster/cmd/syncer/app/options/options.go
+++ b/virtualcluster/cmd/syncer/app/options/options.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"time"
 
 	"k8s.io/utils/pointer"
@@ -126,7 +127,8 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs.BoolVar(&o.ComponentConfig.DisablePodServiceLinks, "disable-service-links", o.ComponentConfig.DisablePodServiceLinks, "DisablePodServiceLinks indicates whether to disable the `EnableServiceLinks` field in pPod spec.")
 	fs.StringSliceVar(&o.ComponentConfig.DefaultOpaqueMetaDomains, "default-opaque-meta-domains", o.ComponentConfig.DefaultOpaqueMetaDomains, "DefaultOpaqueMetaDomains is the default opaque meta configuration for each Virtual Cluster.")
 	fs.StringSliceVar(&o.ComponentConfig.ExtraSyncingResources, "extra-syncing-resources", o.ComponentConfig.ExtraSyncingResources, "ExtraSyncingResources defines additional resources that need to be synced for each Virtual Cluster. (priorityclass, ingress, crd)")
-	fs.Var(cliflag.NewMapStringBool(&o.ComponentConfig.FeatureGates), "feature-gates", "A set of key=value pairs that describe featuregate gates for various features.")
+	fs.Var(cliflag.NewMapStringBool(&o.ComponentConfig.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for various features."+
+		"Options are:\n"+strings.Join(featuregate.DefaultFeatureGate.KnownFeatures(), "\n"))
 	fs.StringSliceVar(&o.ComponentConfig.ExtraNodeLabels, "extra-node-labels", o.ComponentConfig.ExtraNodeLabels, "ExtraNodeLabels defines additional node labels that need to be synced for each Virtual Cluster")
 	fs.StringSliceVar(&o.ComponentConfig.OpaqueTaintKeys, "opaque-taint-keys", o.ComponentConfig.OpaqueTaintKeys, "OpaqueTaintKeys defines taint keys that need to be synced for each Virtual Cluster")
 	fs.Int32Var(&o.ComponentConfig.VNAgentPort, "vn-agent-port", 10550, "Port the vn-agent listens on")


### PR DESCRIPTION
**What this PR does / why we need it**:

As a developer, when more and more feature gates are going to support, there will be some differences between different Syncer versions. In order to check the feature gate supported by a specific version, we hope to support `--help` to display all supported feature gates at current version.

it will output like this:
```bash
 $./syncer --help
The resource syncer is a daemon that watches tenant clusters to
keep tenant requests are synchronized to super cluster by creating corresponding
custom resources on behalf of the tenant users in super cluster.

Usage:
  syncer [flags]

Server flags:

      --feature-gates mapStringBool
                A set of key=value pairs that describe feature gates for various features.Options are:
                ClusterVersionPartialUpgrade=true|false (default=false)
                DisableCRDPreserveUnknownFields=true|false (default=false)
                RootCACertConfigMapSupport=true|false (default=false)
                SuperClusterLabelFilter=true|false (default=false)
                SuperClusterLabelling=true|false (default=false)
                SuperClusterPooling=true|false (default=false)
                SuperClusterServiceNetwork=true|false (default=false)
                TenantAllowDNSPolicy=true|false (default=false)
                TenantAllowResourceNoSync=true|false (default=false)
                VNodeProviderPodIP=true|false (default=false)
                VNodeProviderService=true|false (default=false)
                VServiceExternalIP=true|false (default=false) (default SuperClusterPooling=false,SuperClusterServiceNetwork=false,VNodeProviderService=false)
```

**Which issue(s) this PR fixes**:
Fixes #
