### PR TITLE
🐛 namespace names should valid RFC 1123 DNS labels

### DIFF
--- a/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/virtualcluster/pkg/syncer/conversion/helper.go
@@ -60,7 +60,7 @@ func ToClusterKey(vc *v1alpha1.VirtualCluster) string {
 
 func ToSuperClusterNamespace(cluster, ns string) string {
 	targetNamespace := strings.Join([]string{cluster, ns}, "-")
-	if len(targetNamespace) > validation.DNS1123SubdomainMaxLength {
+	if len(targetNamespace) > validation.DNS1123LabelMaxLength {
 		digest := sha256.Sum256([]byte(targetNamespace))
 		return targetNamespace[0:57] + "-" + hex.EncodeToString(digest[0:])[0:5]
 	}


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
As mentioned here, https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#namespaces-and-dns, all namespace names must be valid RFC 1123 DNS labels.