### PR TITLE
✨  Add LeaderElectionResourceLock flag and generalize leaderElectionID flag name

### DIFF
--- a/virtualcluster/cmd/manager/main.go
+++ b/virtualcluster/cmd/manager/main.go
@@ -69,12 +69,12 @@ func main() {
 	flag.StringVar(&controlPlaneProvisioner, "provisioner", "native",
 		"The underlying platform that will provision control plane for virtualcluster.")
 	flag.BoolVar(&leaderElection, "leader-election", true, "If enable leaderelection for vc-manager")
-	// Deprecated: the flag used resource type as part of the name. Replaced by le-name.
-	flag.StringVar(&leaderElectionCmName, "le-cm-name", "", "DEPRECATED. Use --le-name instead")
-	flag.StringVar(&leaderElectionID, "le-name", "vc-manager-leaderelection-lock",
+	// Deprecated: the flag used resource type as part of the name. Replaced by leader-elect-resource-name.
+	flag.StringVar(&leaderElectionCmName, "le-cm-name", "", "DEPRECATED. Use --leader-elect-resource-name instead")
+	flag.StringVar(&leaderElectionID, "leader-elect-resource-name", "vc-manager-leaderelection-lock",
 		"The name of the resource that will be used as the resourcelock for leaderelection")
-	flag.StringVar(&leaderElectionResourceLock, "le-resource", "configmapsleases",
-		"The type of the resource that will be used as the resourcelock for leaderelection [configmaps, leases, configmapsleases]")
+	flag.StringVar(&leaderElectionResourceLock, "leader-elect-resource-lock", "configmapsleases",
+		"The type of the resource that will be used as the resourcelock for leader election [configmaps, leases, configmapsleases]")
 	flag.IntVar(&maxConcurrentReconciles, "num-reconciles", 10,
 		"The max number reconcilers of virtualcluster controller")
 	flag.StringVar(&logFile, "log-file", "", "The path of the logfile, if not set, only log to the stderr")

--- a/virtualcluster/cmd/manager/main.go
+++ b/virtualcluster/cmd/manager/main.go
@@ -52,6 +52,8 @@ func main() {
 		controlPlaneProvisionerDeprecated string
 		leaderElection                    bool
 		leaderElectionCmName              string
+		leaderElectionID                  string
+		leaderElectionResourceLock        string
 		maxConcurrentReconciles           int
 		versionOpt                        bool
 		disableStacktrace                 bool
@@ -67,8 +69,12 @@ func main() {
 	flag.StringVar(&controlPlaneProvisioner, "provisioner", "native",
 		"The underlying platform that will provision control plane for virtualcluster.")
 	flag.BoolVar(&leaderElection, "leader-election", true, "If enable leaderelection for vc-manager")
-	flag.StringVar(&leaderElectionCmName, "le-cm-name", "vc-manager-leaderelection-lock",
-		"The name of the configmap that will be used as the resourcelook for leaderelection")
+	// Deprecated: the flag used resource type as part of the name. Replaced by le-name.
+	flag.StringVar(&leaderElectionCmName, "le-cm-name", "", "DEPRECATED. Use --le-name instead")
+	flag.StringVar(&leaderElectionID, "le-name", "vc-manager-leaderelection-lock",
+		"The name of the resource that will be used as the resourcelock for leaderelection")
+	flag.StringVar(&leaderElectionResourceLock, "le-resource", "configmapsleases",
+		"The type of the resource that will be used as the resourcelock for leaderelection [configmaps, leases, configmapsleases]")
 	flag.IntVar(&maxConcurrentReconciles, "num-reconciles", 10,
 		"The max number reconcilers of virtualcluster controller")
 	flag.StringVar(&logFile, "log-file", "", "The path of the logfile, if not set, only log to the stderr")
@@ -110,13 +116,19 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	log.Info("setting up manager")
+
+	if leaderElectionCmName != "" {
+		leaderElectionID = leaderElectionCmName
+	}
+
 	mgrOpt := manager.Options{
-		MetricsBindAddress:     metricsAddr,
-		LeaderElection:         leaderElection,
-		LeaderElectionID:       leaderElectionCmName,
-		CertDir:                constants.VirtualClusterWebhookCertDir,
-		Port:                   constants.VirtualClusterWebhookPort,
-		HealthProbeBindAddress: healthAddr,
+		MetricsBindAddress:         metricsAddr,
+		LeaderElection:             leaderElection,
+		LeaderElectionID:           leaderElectionID,
+		LeaderElectionResourceLock: leaderElectionResourceLock,
+		CertDir:                    constants.VirtualClusterWebhookCertDir,
+		Port:                       constants.VirtualClusterWebhookPort,
+		HealthProbeBindAddress:     healthAddr,
 	}
 	mgr, err := ctrl.NewManager(cfg, mgrOpt)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR adds a new flag `--leader-elect-resource-lock` to define the type of leader election resource lock (configmapleases, configmaps or leases). Current default behaviour of controller-runtime sets it to configmapleases, so the controller creates and updates two objects now - ConfigMap and Lease. Adding the flag would help operators to switch controller to use leases only to reduce load to the API and network.

The PR also deprecates the flag `--le-cm-name` because it was using `cm` in it, that could be confusing after the switch to leases; so it introduces the new flag `--leader-elect-resource-name` with the fallback to `--le-cm-name` if it is set explicitly.
