### PR TITLE
🌱 fix: use dl.k8s.io, not kubernetes-release bucket

### DIFF
--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -31,7 +31,7 @@ verify_kubectl_version() {
         mkdir -p "${GOPATH_BIN}"
       fi
       echo 'kubectl not found, installing'
-      curl -sLo "${GOPATH_BIN}/kubectl" https://storage.googleapis.com/kubernetes-release/release/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl
+      curl -sLo "${GOPATH_BIN}/kubectl" https://dl.k8s.io/release/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl
       chmod +x "${GOPATH_BIN}/kubectl"
     else
       echo "Missing required binary in path: kubectl"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
There are still references to https://storage.googleapis.com/kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396
