### PR TITLE
🐛 GetNodeIP returns first ready node

### DIFF
--- a/virtualcluster/pkg/controller/util/net/util.go
+++ b/virtualcluster/pkg/controller/util/net/util.go
@@ -59,7 +59,7 @@ func GetNodeIP(cli client.Client) (string, error) {
 		// Check if the node has the ready status condition
 		for _, condition := range node.Status.Conditions {
 			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
-				//Look for internal IP
+				// Look for internal IP
 				for _, addr := range node.Status.Addresses {
 					if addr.Type == corev1.NodeInternalIP {
 						return addr.Address, nil

--- a/virtualcluster/pkg/controller/util/net/util.go
+++ b/virtualcluster/pkg/controller/util/net/util.go
@@ -54,12 +54,22 @@ func GetNodeIP(cli client.Client) (string, error) {
 	if len(nodeLst.Items) == 0 {
 		return "", errors.New("there is no available nodes")
 	}
-	for _, addr := range nodeLst.Items[0].Status.Addresses {
-		if addr.Type == corev1.NodeInternalIP {
-			return addr.Address, nil
+
+	for _, node := range nodeLst.Items {
+		// Check if the node has the ready status condition
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+				//Look for internal IP
+				for _, addr := range node.Status.Addresses {
+					if addr.Type == corev1.NodeInternalIP {
+						return addr.Address, nil
+					}
+				}
+			}
 		}
 	}
-	return "", errors.New("there is no 'NodeInternalIP' type address")
+
+	return "", errors.New("there is no 'NodeInternalIP' type address with Ready status")
 }
 
 // GetLBIP returns the external ip address assigned to Loadbalancer by


### PR DESCRIPTION
**What this PR does / why we need it**:

The current implementation of kubectl-vc gets the first node in a cluster and stores its IP for the kubeconfig if the vc is set up with a nodeport service. This can cause issues if the chosen node's kubeproxy is down. Changing this to only select a ready node seems safer.

Before:
```
// GetNodeIP returns a node IP address
func GetNodeIP(cli client.Client) (string, error) {
	nodeLst := &corev1.NodeList{}
	if err := cli.List(context.TODO(), nodeLst); err != nil {
		return "", err
	}
	if len(nodeLst.Items) == 0 {
		return "", errors.New("there is no available nodes")
	}
        for _, addr := range nodeLst[0].Status.Addresses {
	        if addr.Type == corev1.NodeInternalIP {
			return addr.Address, nil
	        }
	}
	return "", errors.New("there is no 'NodeInternalIP' type address")
}
```

After:
```
// GetNodeIP returns a node IP address
func GetNodeIP(cli client.Client) (string, error) {
	nodeLst := &corev1.NodeList{}
	if err := cli.List(context.TODO(), nodeLst); err != nil {
		return "", err
	}
	if len(nodeLst.Items) == 0 {
		return "", errors.New("there is no available nodes")
	}

	for _, node := range nodeLst.Items {
		// Check if the node has the ready status condition
		for _, condition := range node.Status.Conditions {
			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
				//Look for internal IP
				for _, addr := range node.Status.Addresses {
					if addr.Type == corev1.NodeInternalIP {
						return addr.Address, nil
					}
				}
			}
		}
	}

	return "", errors.New("there is no 'NodeInternalIP' type address with Ready status")
}
```
