### PR TITLE
Sync PVC's Status.Phase

### DIFF
--- a/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -88,6 +88,13 @@ const (
 	// add clusterIP of pService to vService's externalIPs.
 	// So that vService can be resolved by using the k8s_external plugin in coredns.
 	VServiceExternalIP = "VServiceExternalIP"
+
+	// SyncTenantPVCStatusPhase is an experimental feature that enables the syncer to
+	// update the Status.Phase of a tenant cluster's PVC if it is Bound,
+	// but the corresponding PVC in the super cluster is not Bound, e.g., Lost.
+	// Although rare, this situation can arise due to potential bugs and race conditions.
+	// This feature allows users to perform separate investigation and resolution.
+	SyncTenantPVCStatusPhase = "SyncTenantPVCStatusPhase"
 )
 
 var defaultFeatures = FeatureList{
@@ -103,6 +110,7 @@ var defaultFeatures = FeatureList{
 	DisableCRDPreserveUnknownFields: {Default: false},
 	RootCACertConfigMapSupport:      {Default: false},
 	VServiceExternalIP:              {Default: false},
+	SyncTenantPVCStatusPhase:        {Default: false},
 }
 
 type Feature string


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

The current syncer doesn't sync `PVC.Status.Phase` in a tenant cluster.  We have observed that a super cluster's PV and PVC are  not `Bound` while the the tenant cluster's PV and PVC are `Bound`, which might be caused by bug/race condition in the underlying controllers.  It should never happen. 

It can be reproduced by deleting a bound PVC in a tenant cluster, recreating the PVC and bound it again. The resulting PV and PVC in the tenant cluster will show `Bound` and the PV in the super cluster is `Released` and the PVC is `Pending`.

The PR updates a tenant cluster's PVC `Status.Phase` with the super cluster's `Status.Phase` if the tenant cluster PVC is `Bound` and the super cluster PVC is not `Bound`, e.g., `Pending`, `Lost`. The other conditions are still handled and reconciled by the PV controller. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
